### PR TITLE
Added .rubocop.yml from ManageIQ/guides

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from:
+- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+# put all local rubocop config into .rubocop_local.yml as it will be loaded by .rubocop_cc.yml as well
+- .rubocop_local.yml


### PR DESCRIPTION
Similar to ManageIQ repo's pulls in the .rubocop.yml from the manageiq/guides repo