### PR TITLE
Add service_offering_ref to portfolio_items

### DIFF
--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -15,4 +15,6 @@ class PortfolioItem < ApplicationRecord
 
   attr_accessor :portfolio_id
   has_and_belongs_to_many :portfolios
+
+  validates :service_offering_ref, :presence => true
 end

--- a/db/migrate/20181017200423_add_service_offering_ref_to_portfolio_item.rb
+++ b/db/migrate/20181017200423_add_service_offering_ref_to_portfolio_item.rb
@@ -1,0 +1,8 @@
+class AddServiceOfferingRefToPortfolioItem < ActiveRecord::Migration[5.1]
+  def change
+    say_with_time "Removing all PortfolioItems, adding a new required field: service_offerings_ref" do
+      PortfolioItem.delete_all
+    end
+    add_column :portfolio_items, :service_offering_ref, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181003135506) do
+ActiveRecord::Schema.define(version: 20181017200423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20181003135506) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
+    t.string "service_offering_ref"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end
 

--- a/spec/factories/portfolio_items.rb
+++ b/spec/factories/portfolio_items.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :portfolio_item do
-    sequence(:name)         { |n| "PortfolioItem_name_#{n}" }
-    sequence(:description)  { |n| "PortfolioItem_description_#{n}" }
+    sequence(:name)                 { |n| "PortfolioItem_name_#{n}" }
+    sequence(:description)          { |n| "PortfolioItem_description_#{n}" }
+    sequence(:service_offering_ref) { |n| "#{rand(0)+n}" }
   end
 end


### PR DESCRIPTION
1. Adds `service_offering_ref` to `PortfolioItem`
2. It is a required field, so the migration removes all existing `PortfolioItem` records prior to adding the new field.