### PR TITLE
Remove body parameter from add portfolio item to portfolio endpoint

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -149,7 +149,6 @@ paths:
       parameters:
         - $ref: '#/parameters/PortfolioID'
         - $ref: '#/parameters/PortfolioItemID'
-        - in: body
           name: item
           required: true
           schema:


### PR DESCRIPTION
Remove the `in: body` parameter requirement from the `/portfolios/{portfolio_id}/portfolio_items/{portfolio_item_id}` endpoint.