### PR TITLE
Add service_offering_ref as a parameter for PortfolioItem

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -193,6 +193,7 @@ paths:
       consumes:
         - application/json
       parameters:
+        - $ref: '#/parameters/ServiceOfferingRef'
         - name: body
           in: body
           required: true
@@ -588,6 +589,12 @@ parameters:
     description: The Portfolio Item ID
     required: true
     type: integer
+  ServiceOfferingRef:
+    name: service_offering_ref
+    in: path
+    description: The Service Offering Reference
+    required: true
+    type: string
   OrderID:
     name: order_id
     in: path


### PR DESCRIPTION
We need to add the `service_offering_ref` as a parameter when `POST`ing a new `PortfolioItem`.

This PR adds that value as a required parameter on the swagger doc file.