### PR TITLE
Change integers to strings for portfolio_item_id and portfolio_id

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -581,13 +581,13 @@ parameters:
     in: path
     description: The Portfolio ID
     required: true
-    type: integer
+    type: string
   PortfolioItemID:
     name: portfolio_item_id
     in: path
     description: The Portfolio Item ID
     required: true
-    type: integer
+    type: string
   OrderID:
     name: order_id
     in: path


### PR DESCRIPTION
Needed to remove a few more integers from the swagger file ( changed the type to string. )