### PR TITLE
Rename service objects to be more consistent

### DIFF
--- a/app/services/order_addition_service.rb
+++ b/app/services/order_addition_service.rb
@@ -1,4 +1,4 @@
-class AddToOrder
+class OrderAdditionService
   attr_accessor :params
 
   def initialize(params)

--- a/app/services/order_submission_service.rb
+++ b/app/services/order_submission_service.rb
@@ -1,4 +1,4 @@
-class SubmitOrder < TopologyServiceApi
+class OrderSubmissionService < TopologyApiService
   def process
     order.order_items.each do |order_item|
       submit_order_item(order_item)

--- a/app/services/plan_listing_service.rb
+++ b/app/services/plan_listing_service.rb
@@ -1,9 +1,9 @@
-class ServicePlans < TopologyServiceApi
+class PlanListingService < TopologyApiService
   def process
     result = api_instance.list_service_offering_service_parameters_sets(service_offering_ref)
     filter_result(result)
   rescue StandardError => e
-    Rails.logger.error("Service Plans #{e.message}")
+    Rails.logger.error("Plans #{e.message}")
     raise
   end
 

--- a/app/services/topology_api_service.rb
+++ b/app/services/topology_api_service.rb
@@ -1,5 +1,6 @@
 require 'topological_inventory-api-client'
-class TopologyServiceApi
+
+class TopologyApiService
   attr_accessor :params, :api_instance
   def initialize(options)
     @params = options

--- a/spec/services/order_addition_service_spec.rb
+++ b/spec/services/order_addition_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AddToOrder do
+describe OrderAdditionService do
   let(:service_offering_ref) { "998" }
   let(:order) { create(:order) }
   let(:order_id) { order.id.to_s }
@@ -24,18 +24,18 @@ describe AddToOrder do
   end
 
   it "add order item" do
-      AddToOrder.new(params).process
+      OrderAdditionService.new(params).process
       expect(order.order_items.first.portfolio_item_id).to eq(portfolio_item.id)
   end
 
   it "invalid parameters" do
-    expect { AddToOrder.new(invalid_params).process }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { OrderAdditionService.new(invalid_params).process }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
   context "invalid order" do
     let(:order_id) { "999" }
     it "invalid order" do
-      expect { AddToOrder.new(params).process }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { OrderAdditionService.new(params).process }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/services/plan_listing_service_spec.rb
+++ b/spec/services/plan_listing_service_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe ServicePlans do
+describe PlanListingService do
   let(:service_offering_ref) { "998" }
   let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
-  let(:service_plans) { ServicePlans.new(params) }
+  let(:plan_listing_service) { PlanListingService.new(params) }
   let(:api_instance) { double() }
   let(:params) { {'portfolio_item_id' => portfolio_item.id} }
 
@@ -12,10 +12,10 @@ describe ServicePlans do
       Plan = Struct.new(:name, :id, :description, :create_json_schema)
       plan1 = Plan.new("Plan A", "1", "Plan A", {})
       plan2 = Plan.new("Plan B", "2", "Plan B", {})
-      allow(service_plans).to receive(:api_instance).and_return(api_instance)
+      allow(plan_listing_service).to receive(:api_instance).and_return(api_instance)
     expect(api_instance).to receive(:list_service_offering_service_parameters_sets).with(portfolio_item.service_offering_ref).and_return([plan1, plan2])
 
-      service_plans.process
+      plan_listing_service.process
     end
   end
 
@@ -23,7 +23,7 @@ describe ServicePlans do
     let(:params) { {'portfolio_item_id' => 1 } }
     it "raises exception" do
       with_modified_env TOPOLOGY_SERVICE_URL: 'http://www.example.com' do
-        expect { service_plans.process }.to raise_error(StandardError)
+        expect { plan_listing_service.process }.to raise_error(StandardError)
       end
     end
   end


### PR DESCRIPTION
Simple rename for all the service objects to add `_service` to their names/filenames and adjust the language a bit.

I changed the name a bit from `TopologyServiceApi` to `TopologyApiService` since I felt that based on the code it currently contained, we aren't getting `TopologyService` objects. If that is the case, then I think `TopologyServiceApiService` would be more fitting. (Though, a bit weird).

I changed `ServicePlans` to `PlanListingService` since again, I don't think we're getting `ServicePlan` objects. According to the specs, they are just plain `Plan` objects, but if we want to use the `ServicePlan` naming structure, I would say this could be the `ServicePlanListingService` which again is a bit weird, but that's just how it goes when you have actual objects with `Service` in their name haha.

The other service name changes I think are self explanatory but if there are questions let me know.

@syncrou @gmcculloug @mkanoor Please Review.