### PR TITLE
Changed service_parameter_sets to service_plans

### DIFF
--- a/app/services/service_plans.rb
+++ b/app/services/service_plans.rb
@@ -1,6 +1,6 @@
 class ServicePlans < TopologyServiceApi
   def process
-    result = api_instance.list_service_offering_service_parameters_sets(service_offering_ref)
+    result = api_instance.list_service_offering_service_plans(service_offering_ref)
     filter_result(result)
   rescue StandardError => e
     Rails.logger.error("Service Plans #{e.message}")

--- a/spec/services/service_plans_spec.rb
+++ b/spec/services/service_plans_spec.rb
@@ -13,7 +13,7 @@ describe ServicePlans do
       plan1 = Plan.new("Plan A", "1", "Plan A", {})
       plan2 = Plan.new("Plan B", "2", "Plan B", {})
       allow(service_plans).to receive(:api_instance).and_return(api_instance)
-    expect(api_instance).to receive(:list_service_offering_service_parameters_sets).with(portfolio_item.service_offering_ref).and_return([plan1, plan2])
+    expect(api_instance).to receive(:list_service_offering_service_plans).with(portfolio_item.service_offering_ref).and_return([plan1, plan2])
 
       service_plans.process
     end


### PR DESCRIPTION
The topology service was modified to rename service_parameter_sets to service_plans

https://github.com/ManageIQ/topological_inventory-api/pull/23