### PR TITLE
Refactor how topology grabs service_offering_ref

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -21,6 +21,7 @@ class OrderItem < ApplicationRecord
   validates_presence_of :portfolio_item_id
 
   belongs_to :order
+  belongs_to :portfolio_item
   has_many :progress_messages
   after_initialize :set_defaults, unless: :persisted?
 

--- a/app/services/service_plans.rb
+++ b/app/services/service_plans.rb
@@ -8,7 +8,7 @@ class ServicePlans < TopologyServiceApi
   end
 
   def service_offering_ref
-    PortfolioItem.find_by!(:id => params['portfolio_item_id']).service_offering_ref
+    PortfolioItem.find(params['portfolio_item_id']).service_offering_ref
   end
 
   def filter_result(result)

--- a/app/services/submit_order.rb
+++ b/app/services/submit_order.rb
@@ -2,7 +2,7 @@ class SubmitOrder < TopologyServiceApi
   def process
     order.order_items.each do |order_item|
       submit_order_item(order_item)
-    end 
+    end
     order.update_attributes(:state => 'Ordered', :ordered_at => DateTime.now())
     order
   rescue StandardError => e
@@ -17,10 +17,10 @@ class SubmitOrder < TopologyServiceApi
   end
 
   def submit_order_item(order_item)
-    sor = service_offering_ref(order_item.portfolio_item_id)
+
     # TODO Waiting for Topology Service to implement this
     #result = api_instance.submit_provision_order(order_item.provider_control_parameters,
-    #                                             sor,
+    #                                             order_item.portfolio_item.service_offering_ref,
     #                                             order_item.service_plan_id,
     #                                             order_item.service_parameters)
     order_item.external_ref = "Waiting for toplogy"
@@ -28,9 +28,5 @@ class SubmitOrder < TopologyServiceApi
     order_item.ordered_at   = DateTime.now
     order_item.update_message('info', 'Initialized')
     order_item.save!
-  end
-
-  def service_offering_ref(portfolio_item_id)
-    PortfolioItem.find_by!(:id => portfolio_item_id).service_offering_ref
   end
 end


### PR DESCRIPTION
This change modifies how we access `service_offering_ref` from within requests for `TopologyServiceApi`.