### PR TITLE
Store Encrypted Fields in the Service Portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.ruby-gemset
 /.ruby-version
 /.yardoc
+/v2_key
 /Gemfile.lock
 /_yardoc/
 /bundler.d/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
+- "cp v2_key.dev v2_key"
 - "./cc-test-reporter before-build"
 - bundle exec rake db:create db:migrate
 after_script:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 
 gem 'acts_as_tenant'
 gem 'jbuilder', '~> 2.0'
+gem "manageiq-password", :git => "https://github.com/ManageIQ/manageiq-password", :branch => "master"
 gem 'pg', '~> 1.0', :require => false
 gem 'puma', '~> 3.0'
 gem 'rack-cors', '>= 0.4.1'

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -6,15 +6,15 @@ class Authentication < ApplicationRecord
 
   validates :encryption, :presence => true
 
-  def password=(password)
+  def secret=(secret)
     if encryption.nil?
-      self.encryption = Encryption.new(:password => password)
+      self.encryption = Encryption.new(:secret => secret)
     else
-      encryption.update_attributes(:password => password)
+      encryption.update_attributes(:secret => secret)
     end
   end
 
-  def password
-    encryption.password || nil
+  def secret
+    encryption.secret || nil
   end
 end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,19 @@
+class Authentication < ApplicationRecord
+  acts_as_tenant(:tenant)
+
+  has_one :encryption, :dependent => :destroy
+
+  validates :encryption, :presence => true
+
+  def password=(password)
+    if self.encryption.nil?
+      self.encryption = Encryption.new(:password => password)
+    else
+      self.encryption.update_attributes(:password => password)
+    end
+  end
+
+  def password
+    self.encryption.nil? ? nil : self.encryption.password
+  end
+end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,19 +1,20 @@
 class Authentication < ApplicationRecord
   acts_as_tenant(:tenant)
 
+  belongs_to :resource, :polymorphic => true
   has_one :encryption, :dependent => :destroy
 
   validates :encryption, :presence => true
 
   def password=(password)
-    if self.encryption.nil?
+    if encryption.nil?
       self.encryption = Encryption.new(:password => password)
     else
-      self.encryption.update_attributes(:password => password)
+      encryption.update_attributes(:password => password)
     end
   end
 
   def password
-    self.encryption.nil? ? nil : self.encryption.password
+    encryption.password || nil
   end
 end

--- a/app/models/concerns/encryption_concern.rb
+++ b/app/models/concerns/encryption_concern.rb
@@ -1,4 +1,4 @@
-module PasswordConcern
+module EncryptionConcern
   extend ActiveSupport::Concern
 
   included do
@@ -25,16 +25,16 @@ module PasswordConcern
       end
 
       mod.send(:define_method, "#{column}=") do |val|
-        val = ManageIQ::Password.try_encrypt(val) unless val.blank?
+        val = ManageIQ::Password.try_encrypt(val) if val.present?
         send("#{column}_encrypted=", val)
       end
 
       mod.send(:define_method, "#{column}_encrypted") do
-        read_attribute(column)
+        self[column]
       end
 
       mod.send(:define_method, "#{column}_encrypted=") do |val|
-        write_attribute(column, val)
+        self[column] = val
       end
     end
 

--- a/app/models/concerns/password_concern.rb
+++ b/app/models/concerns/password_concern.rb
@@ -1,0 +1,51 @@
+module PasswordConcern
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :encrypted_columns
+    self.encrypted_columns = []
+  end
+
+  module ClassMethods
+    def encrypt_column(column)
+      # Given a column of "password", create 4 instance methods:
+      #   password            : Get the password in plain text
+      #   password=           : Set the password in plain text
+      #   password_encrypted  : Get the password in cryptext
+      #   password_encrypted= : Set the password in cryptext
+
+      encrypted_columns << column.to_s
+      encrypted_columns << "#{column}_encrypted"
+
+      mod = generated_methods_for_password_mixin
+
+      mod.send(:define_method, column) do
+        val = send("#{column}_encrypted")
+        val.blank? ? val : ManageIQ::Password.decrypt(val)
+      end
+
+      mod.send(:define_method, "#{column}=") do |val|
+        val = ManageIQ::Password.try_encrypt(val) unless val.blank?
+        send("#{column}_encrypted=", val)
+      end
+
+      mod.send(:define_method, "#{column}_encrypted") do
+        read_attribute(column)
+      end
+
+      mod.send(:define_method, "#{column}_encrypted=") do |val|
+        write_attribute(column, val)
+      end
+    end
+
+    private
+
+    def generated_methods_for_password_mixin
+      @generated_methods_for_password_mixin ||= begin
+        mod = const_set(:GeneratedMethodsForPasswordMixin, Module.new)
+        include mod
+        mod
+      end
+    end
+  end
+end

--- a/app/models/encryption.rb
+++ b/app/models/encryption.rb
@@ -1,5 +1,3 @@
-require "password_concern"
-
 class Encryption < ApplicationRecord
   include PasswordConcern
   acts_as_tenant(:tenant)

--- a/app/models/encryption.rb
+++ b/app/models/encryption.rb
@@ -1,10 +1,10 @@
 class Encryption < ApplicationRecord
-  include PasswordConcern
+  include EncryptionConcern
   acts_as_tenant(:tenant)
 
-  validates :authentication_id, :password, :presence => true
+  validates :authentication_id, :secret, :presence => true
 
   belongs_to :authentication
 
-  encrypt_column :password
+  encrypt_column :secret
 end

--- a/app/models/encryption.rb
+++ b/app/models/encryption.rb
@@ -1,0 +1,12 @@
+require "password_concern"
+
+class Encryption < ApplicationRecord
+  include PasswordConcern
+  acts_as_tenant(:tenant)
+
+  validates :authentication_id, :password, :presence => true
+
+  belongs_to :authentication
+
+  encrypt_column :password
+end

--- a/db/migrate/20181126215611_add_authentications.rb
+++ b/db/migrate/20181126215611_add_authentications.rb
@@ -1,0 +1,17 @@
+class AddAuthentications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :authentications, :id => :bigserial do |t|
+      t.string     :name
+      t.string     :authtype
+      t.string     :status
+      t.string     :status_details
+      t.bigint     :tenant_id
+    end
+
+    create_table :encryptions, :id => :bigserial do |t|
+      t.references "authentication", :index => true
+      t.string :password
+      t.bigint :tenant_id
+    end
+  end
+end

--- a/db/migrate/20181126215611_add_authentications.rb
+++ b/db/migrate/20181126215611_add_authentications.rb
@@ -1,17 +1,22 @@
 class AddAuthentications < ActiveRecord::Migration[5.1]
   def change
     create_table :authentications, :id => :bigserial do |t|
+      t.references "resource", :polymorphic => true, :index => true
       t.string     :name
       t.string     :authtype
       t.string     :status
       t.string     :status_details
       t.bigint     :tenant_id
+
+      t.timestamps
     end
 
     create_table :encryptions, :id => :bigserial do |t|
       t.references "authentication", :index => true
       t.string :password
       t.bigint :tenant_id
+
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20181126215611_add_authentications.rb
+++ b/db/migrate/20181126215611_add_authentications.rb
@@ -13,7 +13,7 @@ class AddAuthentications < ActiveRecord::Migration[5.1]
 
     create_table :encryptions, :id => :bigserial do |t|
       t.references "authentication", :index => true
-      t.string :password
+      t.string :secret
       t.bigint :tenant_id
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,17 +16,24 @@ ActiveRecord::Schema.define(version: 20181126215611) do
   enable_extension "plpgsql"
 
   create_table "authentications", force: :cascade do |t|
+    t.string "resource_type"
+    t.bigint "resource_id"
     t.string "name"
     t.string "authtype"
     t.string "status"
     t.string "status_details"
     t.bigint "tenant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_type", "resource_id"], name: "index_authentications_on_resource_type_and_resource_id"
   end
 
   create_table "encryptions", force: :cascade do |t|
     t.bigint "authentication_id"
     t.string "password"
     t.bigint "tenant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["authentication_id"], name: "index_encryptions_on_authentication_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181101134526) do
+ActiveRecord::Schema.define(version: 20181126215611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "authentications", force: :cascade do |t|
+    t.string "name"
+    t.string "authtype"
+    t.string "status"
+    t.string "status_details"
+    t.bigint "tenant_id"
+  end
+
+  create_table "encryptions", force: :cascade do |t|
+    t.bigint "authentication_id"
+    t.string "password"
+    t.bigint "tenant_id"
+    t.index ["authentication_id"], name: "index_encryptions_on_authentication_id"
+  end
 
   create_table "order_items", force: :cascade do |t|
     t.integer "count"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20181126215611) do
 
   create_table "encryptions", force: :cascade do |t|
     t.bigint "authentication_id"
-    t.string "password"
+    t.string "secret"
     t.bigint "tenant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :authentication do
+    sequence(:name) { |n| "Authentication_name_#{n}" }
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,22 @@
+describe Authentication do
+  let(:auth) { build(:authentication) }
+
+  context "encrypt passwords" do
+    before do
+      auth.password = "blah"
+      auth.save
+    end
+    it "encrypts the password field in the encryptions table" do
+      results = ActiveRecord::Base.connection.exec_query("select password from encryptions")
+      rows = results.instance_variable_get(:@rows)[0][0]
+      expect(rows).to match(/v2/)
+      expect(rows).not_to match(/blah/)
+    end
+
+    it "returns the unencrypted version to the caller" do
+      auth.reload
+      expect(auth.password).to eq "blah"
+      expect(auth.password).not_to match(/v2/)
+    end
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,13 +1,13 @@
 describe Authentication do
   let(:auth) { build(:authentication) }
 
-  context "encrypt passwords" do
+  context "encrypt protected data" do
     before do
-      auth.password = "blah"
+      auth.secret = "blah"
       auth.save
     end
-    it "encrypts the password field in the encryptions table" do
-      results = ActiveRecord::Base.connection.exec_query("select password from encryptions")
+    it "encrypts the secret field in the encryptions table" do
+      results = ActiveRecord::Base.connection.exec_query("select secret from encryptions")
       rows = results.instance_variable_get(:@rows)[0][0]
       expect(rows).to match(/v2/)
       expect(rows).not_to match(/blah/)
@@ -15,8 +15,8 @@ describe Authentication do
 
     it "returns the unencrypted version to the caller" do
       auth.reload
-      expect(auth.password).to eq "blah"
-      expect(auth.password).not_to match(/v2/)
+      expect(auth.secret).to eq "blah"
+      expect(auth.secret).not_to match(/v2/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.include FactoryBot::Syntax::Methods

--- a/v2_key.dev
+++ b/v2_key.dev
@@ -1,0 +1,5 @@
+---
+:EZCRYPTO KEY FILE: KEEP THIS SECURE !
+:created: 2014-02-28 09:59:47 -0500
+:algorithm: aes-256-cbc
+:key: uXfIgSAUq5Oz8goc/zI8HOOo0SI++Sd9mfpgBanYIM4=


### PR DESCRIPTION
1. Create an Authentication Model.
2. Save encrypted passwords in an associated `Encryption` model
3. Add the v2_key.dev example key (part of manageiq_password gem requirements.)

Save and Retrieve authentication using the following examples:
```
# Encrypt a password
auth = Authentication.new(:name => 'test')
auth.secret = 'test'
auth.save!

# Retrieve a plaintext version of a password
auth = Authentication.find_by(:name => 'test')
auth.secret
```

