### PR TITLE
Removed the callback_terminator its deprecated

### DIFF
--- a/config/initializers/callback_terminator.rb
+++ b/config/initializers/callback_terminator.rb
@@ -1,6 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Do not halt callback chains when a callback returns false. This is a new
-# Rails 5.0 default, so it is introduced as a configuration option to ensure
-# that apps made with earlier versions of Rails are not affected when upgrading.
-ActiveSupport.halt_callback_chains_on_return_false = false


### PR DESCRIPTION
Fixes #66 

https://blog.bigbinary.com/2016/02/13/rails-5-does-not-halt-callback-chain-when-false-is-returned.html

