### PR TITLE
Renamed external_ref to topology_task_ref

### DIFF
--- a/db/migrate/20181212151455_rename_external_ref.rb
+++ b/db/migrate/20181212151455_rename_external_ref.rb
@@ -1,0 +1,5 @@
+class RenameExternalRef < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :order_items, :external_ref, :topology_task_ref
+  end
+end

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -646,13 +646,6 @@ definitions:
         format: date-time
         title: Completed at
         readOnly: true
-      external_ref:
-        type: string
-        description: >-
-          An external reference from the provider that can be used to track the
-          progress of the order item
-        title: External Reference
-        readOnly: true
   ProgressMessage:
     type: object
     properties:


### PR DESCRIPTION
The external_ref was used when we were interacting directly
with OCP now that we switched to Topology Service the attribute
has to be renamed and not be visible in the swagger yaml