### PR TITLE
Add ability to edit existing portfolio records

### DIFF
--- a/app/controllers/api/v0/admins_controller.rb
+++ b/app/controllers/api/v0/admins_controller.rb
@@ -9,7 +9,12 @@ module Api
       end
 
       def edit_portfolio
-        render json: Portfolio.find(params.require(:portfolio_id)).update(portfolio_params)
+        portfolio = Portfolio.find(params.require(:portfolio_id))
+        portfolio.update!(portfolio_params)
+
+        render :json => portfolio
+      rescue ActiveRecord::RecordInvalid => e
+        render :json => { :errors => e.message }, :status => :unprocessable_entity
       end
 
       def add_portfolio_item_to_portfolio

--- a/app/controllers/api/v0/admins_controller.rb
+++ b/app/controllers/api/v0/admins_controller.rb
@@ -8,6 +8,10 @@ module Api
         render :json => { :errors => e.message }, :status => :unprocessable_entity
       end
 
+      def edit_portfolio
+        render json: Portfolio.find(params.require(:portfolio_id)).update(portfolio_params)
+      end
+
       def add_portfolio_item_to_portfolio
         portfolio = Portfolio.find(params.require(:portfolio_id))
         portfolio_item = PortfolioItem.find(params.require(:portfolio_item_id))

--- a/app/controllers/api/v0/admins_controller.rb
+++ b/app/controllers/api/v0/admins_controller.rb
@@ -13,8 +13,6 @@ module Api
         portfolio.update!(portfolio_params)
 
         render :json => portfolio
-      rescue ActiveRecord::RecordInvalid => e
-        render :json => { :errors => e.message }, :status => :unprocessable_entity
       end
 
       def add_portfolio_item_to_portfolio

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   add_swagger_route 'GET', '/portfolios/{portfolio_id}/portfolio_items/{portfolio_item_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'fetch_portfolio_item_from_portfolio'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}/portfolio_items', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'fetch_portfolio_items_with_portfolio'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'fetch_portfolio_with_id'
-  add_swagger_route 'PATCH', '/portfolios/{portfolio_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'edit_portfolio'
+  add_swagger_route 'PATCH', '/portfolios/{portfolio_id}', :controller_name => 'admins', :constraint_name => 'adminsConstraint', :action_name => 'edit_portfolio'
   add_swagger_route 'GET', '/orders/{order_id}/items/{order_item_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'list_order_item'
   add_swagger_route 'GET', '/orders/{order_id}/items', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'list_order_items'
   add_swagger_route 'GET', '/orders', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'list_orders'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   add_swagger_route 'GET', '/portfolios/{portfolio_id}/portfolio_items/{portfolio_item_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'fetch_portfolio_item_from_portfolio'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}/portfolio_items', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'fetch_portfolio_items_with_portfolio'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'fetch_portfolio_with_id'
+  add_swagger_route 'PATCH', '/portfolios/{portfolio_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'edit_portfolio'
   add_swagger_route 'GET', '/orders/{order_id}/items/{order_item_id}', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'list_order_item'
   add_swagger_route 'GET', '/orders/{order_id}/items', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'list_order_items'
   add_swagger_route 'GET', '/orders', controller_name: 'admins', constraint_name: 'adminsConstraint', action_name: 'list_orders'

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -109,6 +109,35 @@ paths:
           description: Portfolio object not found
         '422':
           $ref: '#/responses/InvalidEntity'
+    patch:
+      tags:
+        - admins
+      summary: Edit an existing portfolio
+      operationId: editPortfolio
+      description: |
+        Returns the edited portfolio object
+      produces:
+        - application/json
+      consumes:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/PortfolioID'
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Portfolio'
+      responses:
+        '200':
+          description: Edited portfolio object
+          schema:
+            $ref: '#/definitions/Portfolio'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '422':
+          $ref: '#/responses/InvalidEntity'
   '/portfolios/{portfolio_id}/portfolio_items':
     get:
       tags:

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -1,0 +1,131 @@
+describe 'Portfolios API' do
+  include RequestSpecHelper
+  include ServiceSpecHelper
+
+  let!(:portfolio)            { create(:portfolio) }
+  let!(:portfolio_item)       { create(:portfolio_item) }
+  let!(:portfolio_items)      { create_list(:portfolio_item, 3, :portfolios => [portfolio]) }
+  let(:portfolio_id)          { portfolio.id }
+  let(:portfolio_item_id)     { portfolio_items.first.id }
+  let(:new_portfolio_item_id) { portfolio_item.id }
+  let(:tenant)                { create(:tenant, :with_external_tenant) }
+
+  %w(admin user).each do |tag|
+    describe "GET #{tag} tagged /portfolios/:portfolio_id" do
+      before do
+        get "#{api}/portfolios/#{portfolio_id}", :headers => send("#{tag}_headers")
+      end
+
+      context 'when portfolios exist' do
+        it 'returns status code 200' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns all portfolio requests' do
+          expect(json).not_to be_empty
+          expect(json['id']).to eq(portfolio_id)
+        end
+      end
+    end
+
+    describe "GET #{tag} tagged /portfolios/:portfolio_id/portfolio_items" do
+      before do
+        get "#{api}/portfolios/#{portfolio_id}/portfolio_items", :headers => send("#{tag}_headers")
+      end
+
+      it 'returns all associated portfolio_items' do
+        expect(json).not_to be_empty
+        expect(json.count).to eq 3
+        portfolio_item_ids = portfolio_items.map(&:id).sort
+        expect(json.map { |x| x['id'] }.sort).to eq portfolio_item_ids
+      end
+    end
+
+    describe "GET #{tag} tagged /portfolios/:portfolio_id/portfolio_items/:portfolio_item_id" do
+      before do
+        get "#{api}/portfolios/#{portfolio_id}/portfolio_items/#{portfolio_item_id}", :headers => send("#{tag}_headers")
+      end
+
+      it 'returns an associated portfolio_item for a specific portfolio' do
+        expect(json).not_to be_empty
+        expect(json['id']).to eq portfolio_item_id
+      end
+    end
+
+    describe "GET #{tag} tagged /portfolios" do
+      before do
+        get "#{api}/portfolios", :headers => send("#{tag}_headers")
+      end
+
+      context 'when portfolios exist' do
+        it 'returns status code 200' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns all portfolio requests' do
+          expect(json.size).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe 'admin tagged /portfolios', :type => :routing do
+    let(:valid_attributes) { { :name => 'rspec 1', :description => 'rspec 1 description' } }
+    context 'with wrong header' do
+      it 'returns a 404' do
+        expect(:post => "/portfolios").not_to be_routable
+      end
+    end
+  end
+
+  describe 'PATCH admin tagged /portfolios/:portfolio_id' do
+    let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'description for patched portfolio' } }
+    let(:invalid_attributes) { { :fred => 'nope', :bob => 'bob portfolio' } }
+    context 'when patched portfolio is valid' do
+      before do
+        patch "#{api}/portfolios/#{portfolio_id}", :headers => admin_headers, :params => valid_attributes
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns an updated portfolio object' do
+        expect(json).not_to be_empty
+        expect(json).to be_a Hash
+        expect(json['name']).to eq valid_attributes[:name]
+      end
+    end
+
+    context 'when patched portfolio params are invalid' do
+      before do
+        patch "#{api}/portfolios/#{portfolio_id}", :headers => admin_headers, :params => invalid_attributes
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns an updated portfolio object' do
+        expect(json).not_to be_empty
+        expect(json).to be_a Hash
+        expect(json['name']).to_not eq invalid_attributes[:name]
+      end
+    end
+  end
+
+  describe 'POST admin tagged /portfolios' do
+    let(:valid_attributes) { { :name => 'rspec 1', :description => 'rspec 1 description' } }
+    context 'when portfolio attributes are valid' do
+      before { post "#{api}/portfolios", :params => valid_attributes, :headers => admin_headers }
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns the new portfolio' do
+        expect(json['name']).to eq valid_attributes[:name]
+      end
+    end
+  end
+end

--- a/spec/support/requests_spec_helper.rb
+++ b/spec/support/requests_spec_helper.rb
@@ -1,0 +1,10 @@
+module RequestSpecHelper
+  # Parse JSON response to ruby hash
+  def json
+    JSON.parse(response.body)
+  end
+
+  def api
+    "/api/v0.0"
+  end
+end


### PR DESCRIPTION
Add a new `patch` route to edit a portfolio.
Add integration specs for portfolios, including the new `patch` method `edit_portfolio`.