### PR TITLE
Remove habtm relationship on portfolios

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -15,8 +15,7 @@ class Portfolio < ApplicationRecord
 
   validates_presence_of :name
   validates_presence_of :description
-
-  has_and_belongs_to_many :portfolio_items
+  has_many :portfolio_items
 
   def add_portfolio_item(portfolio_item_id)
     portfolio_item = PortfolioItem.find_by(id: portfolio_item_id)

--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -14,7 +14,7 @@ class PortfolioItem < ApplicationRecord
   acts_as_tenant(:tenant)
 
   attr_accessor :portfolio_id
-  has_and_belongs_to_many :portfolios
+  belongs_to :portfolios
 
   validates :service_offering_ref, :presence => true
 

--- a/db/migrate/20190102182940_remove_join_table.rb
+++ b/db/migrate/20190102182940_remove_join_table.rb
@@ -1,12 +1,12 @@
-class PortfolioItem < ActiveRecord::Base
-  has_and_belongs_to_many :portfolios
-end
-
-class Portfolio < ActiveRecord::Base
-  has_and_belongs_to_many :portfolio_items
-end
-
 class RemoveJoinTable < ActiveRecord::Migration[5.1]
+  class PortfolioItem < ActiveRecord::Base
+    has_and_belongs_to_many :portfolios
+  end
+
+  class Portfolio < ActiveRecord::Base
+    has_and_belongs_to_many :portfolio_items
+  end
+
   def up
     add_column :portfolio_items, :portfolio_id, :bigint
 

--- a/db/migrate/20190102182940_remove_join_table.rb
+++ b/db/migrate/20190102182940_remove_join_table.rb
@@ -1,0 +1,32 @@
+class PortfolioItem < ActiveRecord::Base
+  has_and_belongs_to_many :portfolios
+end
+
+class Portfolio < ActiveRecord::Base
+  has_and_belongs_to_many :portfolio_items
+end
+
+class RemoveJoinTable < ActiveRecord::Migration[5.1]
+  def up
+    add_column :portfolio_items, :portfolio_id, :bigint
+
+    PortfolioItem.all.each do |portfolio_item|
+      portfolio_item.update_attribute('portfolio_id', portfolio_item.portfolios.first.id) if portfolio_item.portfolios.present?
+    end
+
+    drop_join_table :portfolios, :portfolio_items
+  end
+
+  def down
+    create_join_table :portfolios, :portfolio_items do |t|
+      t.index [:portfolio_id, :portfolio_item_id], name: 'index_items_on_portfolio_id_and_portfolio_item_id'
+      t.index [:portfolio_item_id, :portfolio_id], name: 'index_items_on_portfolio_item_id_and_portfolio_id'
+    end
+
+    PortfolioItem.all.each do |portfolio_item|
+      portfolio_item.portfolios << Portfolio.find(portfolio_item.portfolio_id) if portfolio_item.portfolio_id
+    end
+
+    remove_column :portfolio_items, :portfolio_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181212151455) do
+ActiveRecord::Schema.define(version: 20190102182940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,14 +54,8 @@ ActiveRecord::Schema.define(version: 20181212151455) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.string "service_offering_ref"
+    t.bigint "portfolio_id"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
-  end
-
-  create_table "portfolio_items_portfolios", id: false, force: :cascade do |t|
-    t.bigint "portfolio_id", null: false
-    t.bigint "portfolio_item_id", null: false
-    t.index ["portfolio_id", "portfolio_item_id"], name: "index_items_on_portfolio_id_and_portfolio_item_id"
-    t.index ["portfolio_item_id", "portfolio_id"], name: "index_items_on_portfolio_item_id_and_portfolio_id"
   end
 
   create_table "portfolios", force: :cascade do |t|

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -2,11 +2,11 @@ describe "PortfolioItemRequests", :type => :request do
   include ServiceSpecHelper
 
   let(:service_offering_ref) { "998" }
-  let(:order) { create(:order) }
-  let(:portfolio_item) { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
-  let(:svc_object) { instance_double("ServiceCatalog::ServicePlans") }
-  let(:plans) { [{}, {}] }
-  let(:topo_ex) { ServiceCatalog::TopologyError.new("kaboom") }
+  let(:order)                { create(:order) }
+  let(:portfolio_item)       { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+  let(:svc_object)           { instance_double("ServiceCatalog::ServicePlans") }
+  let(:plans)                { [{}, {}] }
+  let(:topo_ex)              { ServiceCatalog::TopologyError.new("kaboom") }
 
   before do
     allow(ServiceCatalog::ServicePlans).to receive(:new).with(portfolio_item.id.to_s).and_return(svc_object)

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -4,7 +4,7 @@ describe 'Portfolios API' do
 
   let!(:portfolio)            { create(:portfolio) }
   let!(:portfolio_item)       { create(:portfolio_item) }
-  let!(:portfolio_items)      { create_list(:portfolio_item, 3, :portfolios => [portfolio]) }
+  let!(:portfolio_items)      { portfolio.portfolio_items << portfolio_item }
   let(:portfolio_id)          { portfolio.id }
   let(:portfolio_item_id)     { portfolio_items.first.id }
   let(:new_portfolio_item_id) { portfolio_item.id }
@@ -35,7 +35,7 @@ describe 'Portfolios API' do
 
       it 'returns all associated portfolio_items' do
         expect(json).not_to be_empty
-        expect(json.count).to eq 3
+        expect(json.count).to eq 1
         portfolio_item_ids = portfolio_items.map(&:id).sort
         expect(json.map { |x| x['id'] }.sort).to eq portfolio_item_ids
       end


### PR DESCRIPTION
1. Removes the has and belongs to many relationship on both portfolios and portfolio items.
2. Adjusts the specs and code accordingly.