### PR TITLE
Update ruby gems for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
   - DATABASE_URL="postgresql://postgres:@localhost:5432/service_portal_test?encoding=utf8&pool=5&wait_timeout=5"
 before_install:
+- gem update --system
 - gem install bundler
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Allow Travis to install the latest bundler by forcing a rubygem update.