### PR TITLE
Removed order_items from order object

### DIFF
--- a/db/migrate/20190104200809_remove_order_items_from_order.rb
+++ b/db/migrate/20190104200809_remove_order_items_from_order.rb
@@ -1,0 +1,5 @@
+class RemoveOrderItemsFromOrder < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :orders, :order_items, :string
+  end
+end

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -630,10 +630,6 @@ definitions:
         type: string
         format: date-time
         title: Completed at
-      order_items:
-        type: array
-        items:
-          $ref: '#/definitions/OrderItem'
   OrderItem:
     type: object
     required:


### PR DESCRIPTION
The order_items is a relationship from the order object. An order has 1 or more order items.
When we fetch the order we should not be sending back the order_items. It can be retrieved separately from a /orders/{order_id}/items call.