### PR TITLE
Add a new column to PortfolioItem to store service_offering_source_ref

### DIFF
--- a/app/services/service_catalog/service_offering.rb
+++ b/app/services/service_catalog/service_offering.rb
@@ -4,6 +4,7 @@ module ServiceCatalog
       @name = nil
       @description = nil
       @service_offering_ref = nil
+      @service_offering_source_ref = nil
     end
 
     def self.find(id)
@@ -14,6 +15,7 @@ module ServiceCatalog
       @service_offering_ref = id
       TopologicalInventory.call do |api_instance|
         obj = api_instance.show_service_offering(id)
+        @service_offering_source_ref = obj.source_id
         apply_instance_vars(obj)
       end
     end

--- a/db/migrate/20190116194409_add_service_offering_source_ref_to_portfolio_items.rb
+++ b/db/migrate/20190116194409_add_service_offering_source_ref_to_portfolio_items.rb
@@ -1,0 +1,5 @@
+class AddServiceOfferingSourceRefToPortfolioItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :portfolio_items, :service_offering_source_ref, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190104200809) do
+ActiveRecord::Schema.define(version: 20190116194409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20190104200809) do
     t.bigint "tenant_id"
     t.string "service_offering_ref"
     t.bigint "portfolio_id"
+    t.string "service_offering_source_ref"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end
 

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -5,7 +5,7 @@ describe "PortfolioItemRequests", :type => :request do
   let(:service_offering_source_ref) { "568" }
   let(:order)                { create(:order) }
   let(:portfolio_item)       do
-    create(:portfolio_item, :service_offering_ref => service_offering_ref,
+    create(:portfolio_item, :service_offering_ref        => service_offering_ref,
                             :service_offering_source_ref => service_offering_source_ref)
   end
   let(:portfolio_item_id)    { portfolio_item.id }

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -2,8 +2,12 @@ describe "PortfolioItemRequests", :type => :request do
   include ServiceSpecHelper
 
   let(:service_offering_ref) { "998" }
+  let(:service_offering_source_ref) { "568" }
   let(:order)                { create(:order) }
-  let(:portfolio_item)       { create(:portfolio_item, :service_offering_ref => service_offering_ref) }
+  let(:portfolio_item)       do
+    create(:portfolio_item, :service_offering_ref => service_offering_ref,
+                            :service_offering_source_ref => service_offering_source_ref)
+  end
   let(:portfolio_item_id)    { portfolio_item.id }
   let(:svc_object)           { instance_double("ServiceCatalog::ServicePlans") }
   let(:plans)                { [{}, {}] }

--- a/spec/services/service_catalog/service_offering_spec.rb
+++ b/spec/services/service_catalog/service_offering_spec.rb
@@ -4,11 +4,13 @@ describe ServiceCatalog::ServiceOffering do
   let(:api_instance) { double }
   let(:service_offering) { described_class.new }
   let(:service_offering_ref) { "1" }
+  let(:service_offering_source_ref) { "45" }
   let(:name) { 'test name' }
   let(:description) { 'test description' }
   let(:ivars) do
     [{:@name => name}, {:@description => description},
-     {:@service_offering_ref => service_offering_ref}]
+     {:@service_offering_ref => service_offering_ref},
+     {:@service_offering_source_ref => service_offering_source_ref}]
   end
   let(:topology_service_offering) do
     TopologicalInventoryApiClient::ServiceOffering.new('name'        => name,
@@ -16,7 +18,7 @@ describe ServiceCatalog::ServiceOffering do
                                                        'description' => description,
                                                        'source_ref'  => '123',
                                                        'extra'       => {},
-                                                       'source_id'   => '45')
+                                                       'source_id'   => service_offering_source_ref)
   end
 
   let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }
@@ -43,11 +45,12 @@ describe ServiceCatalog::ServiceOffering do
     service_params = service_offering.to_normalized_params
 
     expect(service_params).to be_a Hash
-    expect(service_params.count).to eql 3
+    expect(service_params.count).to eql 4
     expect(service_params).to include(
       'name'                 => name,
       'description'          => description,
-      'service_offering_ref' => service_offering_ref
+      'service_offering_ref' => service_offering_ref,
+      'service_offering_source_ref' => service_offering_source_ref
     )
   end
 end

--- a/spec/services/service_catalog/service_offering_spec.rb
+++ b/spec/services/service_catalog/service_offering_spec.rb
@@ -47,9 +47,9 @@ describe ServiceCatalog::ServiceOffering do
     expect(service_params).to be_a Hash
     expect(service_params.count).to eql 4
     expect(service_params).to include(
-      'name'                 => name,
-      'description'          => description,
-      'service_offering_ref' => service_offering_ref,
+      'name'                        => name,
+      'description'                 => description,
+      'service_offering_ref'        => service_offering_ref,
       'service_offering_source_ref' => service_offering_source_ref
     )
   end


### PR DESCRIPTION
Portfolio items have a new column to store the source_id.
We map source_id from topology_inventory_service as service_offering_source_ref.
This information is needed to access the platform (source) information from a portfolio