### PR TITLE
Added support for Provider Control Parameters

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -57,6 +57,11 @@ module Api
         render :json => so.process.items
       end
 
+      def fetch_provider_control_parameters
+        so = ServiceCatalog::ProviderControlParameters.new(params.require(:portfolio_item_id))
+        render :json => so.process.data
+      end
+
       def topology_service_error(err)
         render :json => {:message => err.message}, :status => :internal_server_error
       end

--- a/app/services/service_catalog/provider_control_parameters.rb
+++ b/app/services/service_catalog/provider_control_parameters.rb
@@ -7,7 +7,7 @@ module ServiceCatalog
     end
 
     def process
-      source_ref = service_offering_source_ref
+      source_ref = PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
       TopologicalInventory.call do |api_instance|
         # TODO: Temporay till we get this call in the topology service
         projects = api_instance.list_container_projects.select { |p| p.source_id == source_ref }
@@ -29,10 +29,6 @@ module ServiceCatalog
     def read_control_parameters
       # TODO: This belongs in the topology service, temporarily hosting it in service portal
       File.read(Rails.root.join("schemas", "json", "openshift_control_parameters.json"))
-    end
-
-    def service_offering_source_ref
-      PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
     end
   end
 end

--- a/app/services/service_catalog/provider_control_parameters.rb
+++ b/app/services/service_catalog/provider_control_parameters.rb
@@ -1,0 +1,38 @@
+module ServiceCatalog
+  class ProviderControlParameters
+    attr_reader :data
+    def initialize(portfolio_item_id)
+      @portfolio_item_id = portfolio_item_id
+      @data = {}
+    end
+
+    def process
+      source_ref = service_offering_source_ref
+      TopologicalInventory.call do |api_instance|
+        # TODO: Temporay till we get this call in the topology service
+        projects = api_instance.list_container_projects.select { |p| p.source_id == source_ref }
+        update_project_list(projects.collect(&:name))
+        self
+      end
+    rescue StandardError => e
+      Rails.logger.error("ProviderControlParameters #{e.message}")
+      raise
+    end
+
+    private
+
+    def update_project_list(projects)
+      @data = JSON.parse(read_control_parameters)
+      @data['properties']['namespace']['enum'] = projects
+    end
+
+    def read_control_parameters
+      # TODO: This belongs in the topology service, temporarily hosting it in service portal
+      File.read(Rails.root.join("schemas", "json", "openshift_control_parameters.json"))
+    end
+
+    def service_offering_source_ref
+      PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   add_swagger_route 'POST', '/portfolios/{portfolio_id}/portfolio_items', :controller_name => 'admins', :action_name => 'add_portfolio_item_to_portfolio'
   add_swagger_route 'POST', '/orders/{order_id}/items', :controller_name => 'admins', :action_name => 'add_to_order'
   add_swagger_route 'GET', '/portfolio_items/{portfolio_item_id}/service_plans', :controller_name => 'admins', :action_name => 'fetch_plans_with_portfolio_item_id'
+  add_swagger_route 'GET', '/portfolio_items/{portfolio_item_id}/provider_control_parameters', :controller_name => 'admins', :action_name => 'fetch_provider_control_parameters'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}/portfolio_items/{portfolio_item_id}', :controller_name => 'admins', :action_name => 'fetch_portfolio_item_from_portfolio'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}/portfolio_items', :controller_name => 'admins', :action_name => 'fetch_portfolio_items_with_portfolio'
   add_swagger_route 'GET', '/portfolios/{portfolio_id}', :controller_name => 'admins', :action_name => 'fetch_portfolio_with_id'

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -311,16 +311,18 @@ paths:
       parameters:
         - $ref: '#/parameters/PortfolioItemID'
       responses:
-        204:
+        '204':
           description: Portfolio Item deleted
-        404:
+        '404':
           description: Portfolio Item not Found
   '/portfolio_items/{portfolio_item_id}/service_plans':
     get:
       tags:
         - users
         - admins
-      summary: Fetches all the service plans for a specific portfolio item, this requires a connection to the topology service.
+      summary: >-
+        Fetches all the service plans for a specific portfolio item, this
+        requires a connection to the topology service.
       operationId: fetchPlansWithPortfolioItemId
       description: |
         Fetch all service plans for a portfolio item
@@ -335,6 +337,33 @@ paths:
             type: array
             items:
               $ref: '#/definitions/ServicePlan'
+        '401':
+          $ref: '#/responses/Unauthorized'
+        '403':
+          $ref: '#/responses/Forbidden'
+        '404':
+          description: Portfolio Item Not found
+        '500':
+          description: Could not access the Topology Service
+  '/portfolio_items/{portfolio_item_id}/provider_control_parameters':
+    get:
+      tags:
+        - users
+        - admins
+      summary: >-
+        Fetches the provider control parameters for this portfolio item, it needs to be provided when provisioning the portfolio item.
+      operationId: fetchProviderControlParameters
+      description: |
+        Fetch provider control parameters for a portfolio item
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/PortfolioItemID'
+      responses:
+        '200':
+          description: Return Provider control parameters JSON object
+          schema:
+            $ref: '#/definitions/ProviderControlParameters'
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
@@ -382,7 +411,7 @@ paths:
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
-          $ref: '#/responses/Forbidden'    
+          $ref: '#/responses/Forbidden'
   '/orders/{order_id}/items':
     get:
       tags:
@@ -406,7 +435,7 @@ paths:
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
-          $ref: '#/responses/Forbidden'      
+          $ref: '#/responses/Forbidden'
     post:
       tags:
         - users
@@ -432,7 +461,7 @@ paths:
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
-          $ref: '#/responses/Forbidden'  
+          $ref: '#/responses/Forbidden'
         '404':
           description: order not found.
   '/orders/{order_id}/items/{order_item_id}':
@@ -457,9 +486,9 @@ paths:
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
-          $ref: '#/responses/Forbidden'  
+          $ref: '#/responses/Forbidden'
         '404':
-          description: Either the order or the order item could not be found.    
+          description: Either the order or the order item could not be found.
   '/orders/{order_id}':
     post:
       tags:
@@ -480,9 +509,9 @@ paths:
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
-          $ref: '#/responses/Forbidden'  
+          $ref: '#/responses/Forbidden'
         '404':
-          description: order not found    
+          description: order not found
   '/order_items/{order_item_id}/progress_messages':
     get:
       tags:
@@ -507,9 +536,9 @@ paths:
         '401':
           $ref: '#/responses/Unauthorized'
         '403':
-          $ref: '#/responses/Forbidden'  
+          $ref: '#/responses/Forbidden'
         '404':
-          description: order item not found     
+          description: order item not found
 parameters:
   PortfolioID:
     name: portfolio_id
@@ -759,6 +788,10 @@ definitions:
         title: JSON Schema
         description: JSON Schema for the object
         readOnly: true
+  ProviderControlParameters:
+    type: object
+    title: Provider Control Parameters
+    description: JSON Schema for Provider control parameters
 responses:
   InvalidEntity:
     description: >-

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -463,7 +463,7 @@ paths:
         '403':
           $ref: '#/responses/Forbidden'
         '404':
-          description: order not found.
+          description: Order not found.
   '/orders/{order_id}/items/{order_item_id}':
     get:
       tags:
@@ -538,7 +538,7 @@ paths:
         '403':
           $ref: '#/responses/Forbidden'
         '404':
-          description: order item not found
+          description: Order item not found
 parameters:
   PortfolioID:
     name: portfolio_id

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -511,7 +511,7 @@ paths:
         '403':
           $ref: '#/responses/Forbidden'
         '404':
-          description: order not found
+          description: Order not found
   '/order_items/{order_item_id}/progress_messages':
     get:
       tags:

--- a/schemas/json/openshift_control_parameters.json
+++ b/schemas/json/openshift_control_parameters.json
@@ -1,0 +1,18 @@
+{
+	"title": "Openshift control parameters",
+	"description": "Openshift provider control parameters",
+	"type": "object",
+	"required": [
+		"namespace"
+	],
+	"properties": {
+		"namespace": {
+			"type": "string",
+			"title": "Openshift Project",
+			"enum": [
+					"default"
+				]
+		}
+	}
+
+}

--- a/spec/factories/portfolio_items.rb
+++ b/spec/factories/portfolio_items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :portfolio_item do
     sequence(:name)                 { |n| "PortfolioItem_name_#{n}" }
     sequence(:description)          { |n| "PortfolioItem_description_#{n}" }
-    sequence(:service_offering_ref) { |n| "#{rand(0)+n}" }
-    sequence(:service_offering_source_ref) { |n| "#{rand(0)+n}" }
+    sequence(:service_offering_ref) { |n| (rand(0) + n).to_s }
+    sequence(:service_offering_source_ref) { |n| (rand(0) + n).to_s }
   end
 end

--- a/spec/factories/portfolio_items.rb
+++ b/spec/factories/portfolio_items.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:name)                 { |n| "PortfolioItem_name_#{n}" }
     sequence(:description)          { |n| "PortfolioItem_description_#{n}" }
     sequence(:service_offering_ref) { |n| "#{rand(0)+n}" }
+    sequence(:service_offering_source_ref) { |n| "#{rand(0)+n}" }
   end
 end

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -9,16 +9,10 @@ describe "PortfolioItemRequests", :type => :request do
                             :service_offering_source_ref => service_offering_source_ref)
   end
   let(:portfolio_item_id)    { portfolio_item.id }
-  let(:svc_object)           { instance_double("ServiceCatalog::ServicePlans") }
-  let(:plans)                { [{}, {}] }
   let(:topo_ex)              { ServiceCatalog::TopologyError.new("kaboom") }
 
-  before do
-    allow(ServiceCatalog::ServicePlans).to receive(:new).with(portfolio_item.id.to_s).and_return(svc_object)
-  end
-
   describe 'DELETE admin tagged /portfolio_items/:portfolio_item_id' do
-    #TODO https://github.com/ManageIQ/service_portal-api/issues/85
+    # TODO: https://github.com/ManageIQ/service_portal-api/issues/85
     let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'description for patched portfolio' } }
 
     context 'when :portfolio_item_id is valid' do
@@ -32,21 +26,57 @@ describe "PortfolioItemRequests", :type => :request do
     end
   end
 
-  it "fetches plans" do
-    allow(svc_object).to receive(:process).and_return(svc_object)
-    allow(svc_object).to receive(:items).and_return(plans)
+  context "service plans" do
+    let(:svc_object)           { instance_double("ServiceCatalog::ServicePlans") }
+    let(:plans)                { [{}, {}] }
 
-    get "/api/v0.0/portfolio_items/#{portfolio_item.id}/service_plans"
+    before do
+      allow(ServiceCatalog::ServicePlans).to receive(:new).with(portfolio_item.id.to_s).and_return(svc_object)
+    end
 
-    expect(JSON.parse(response.body).count).to eq(2)
-    expect(response.content_type).to eq("application/json")
-    expect(response).to have_http_status(:ok)
+    it "fetches plans" do
+      allow(svc_object).to receive(:process).and_return(svc_object)
+      allow(svc_object).to receive(:items).and_return(plans)
+
+      get "/api/v0.0/portfolio_items/#{portfolio_item.id}/service_plans"
+
+      expect(JSON.parse(response.body).count).to eq(2)
+      expect(response.content_type).to eq("application/json")
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "raises error" do
+      allow(svc_object).to receive(:process).and_raise(topo_ex)
+
+      get "/api/v0.0/portfolio_items/#{portfolio_item.id}/service_plans"
+      expect(response).to have_http_status(:internal_server_error)
+    end
   end
 
-  it "raises error" do
-    allow(svc_object).to receive(:process).and_raise(topo_ex)
+  context "provider control parameters" do
+    let(:svc_object)  { instance_double("ServiceCatalog::ProviderControlParameters") }
+    let(:url)         { "/api/v0.0/portfolio_items/#{portfolio_item.id}/provider_control_parameters" }
 
-    get "/api/v0.0/portfolio_items/#{portfolio_item.id}/service_plans"
-    expect(response).to have_http_status(:internal_server_error)
+    before do
+      allow(ServiceCatalog::ProviderControlParameters).to receive(:new).with(portfolio_item.id.to_s).and_return(svc_object)
+    end
+
+    it "fetches plans" do
+      allow(svc_object).to receive(:process).and_return(svc_object)
+      allow(svc_object).to receive(:data).and_return(:fred => 'bedrock')
+
+      get url
+
+      expect(response.content_type).to eq("application/json")
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "raises error" do
+      allow(svc_object).to receive(:process).and_raise(topo_ex)
+
+      get url
+
+      expect(response).to have_http_status(:internal_server_error)
+    end
   end
 end

--- a/spec/services/service_catalog/provider_control_parameters_spec.rb
+++ b/spec/services/service_catalog/provider_control_parameters_spec.rb
@@ -1,0 +1,40 @@
+describe ServiceCatalog::ProviderControlParameters do
+  include ServiceSpecHelper
+
+  let(:api_instance) { double }
+  let(:provider_control) { described_class.new }
+  let(:name) { 'project1' }
+  let(:description) { 'test description' }
+  let(:source_id) { "1" }
+  let(:params) { portfolio_item.id }
+  let(:provider_control_parameters) { described_class.new(params) }
+  let(:portfolio_item) { create(:portfolio_item, :service_offering_source_ref => source_id) }
+  let(:project1) do
+    TopologicalInventoryApiClient::ContainerProject.new('name'      => "project one",
+                                                        'source_id' => "1")
+  end
+  let(:project2) do
+    TopologicalInventoryApiClient::ContainerProject.new('name'      => "project one",
+                                                        'source_id' => "2")
+  end
+
+  let(:ti_class) { class_double("TopologicalInventory").as_stubbed_const(:transfer_nested_constants => true) }
+
+  before do
+    allow(ti_class).to receive(:call).and_yield(api_instance)
+  end
+
+  it "#{described_class}#process" do
+    expect(api_instance).to receive(:list_container_projects).and_return([project1, project2])
+
+    data = provider_control_parameters.process.data
+    expect(data['properties']['namespace']['enum'].first).to eq("project one")
+  end
+
+  context "invalid portfolio item" do
+    let(:params) { 1 }
+    it "raises exception" do
+      expect { provider_control_parameters.process }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
For each provider (source) we need specific information related to
provisioning. For e.g. on Openshift platform we need to let the user
pick a project (namespace) where the provision should happen.
This is a temporary solution till we can get the topology service to
provide us the provider control parameters.

We pass in a portfolio_item_id and it returns a JSON schema that the
UI can render