### PR TITLE
Fix PortfolioItem belongs_to :portfolio statement

### DIFF
--- a/app/models/portfolio_item.rb
+++ b/app/models/portfolio_item.rb
@@ -14,7 +14,7 @@ class PortfolioItem < ApplicationRecord
   acts_as_tenant(:tenant)
 
   attr_accessor :portfolio_id
-  belongs_to :portfolios
+  belongs_to :portfolio
 
   validates :service_offering_ref, :presence => true
 


### PR DESCRIPTION
Small fix (from generated code I assume) for PortfolioItem, it originally had:
`belongs_to :portfolios` 
but standard rails syntax is:
`belongs_to :portfolio`

This just remediates it, even though rails is smart enough to figure out it has a plural syntax. 