### PR TITLE
Migration for new fields in PortfolioItem

### DIFF
--- a/db/migrate/20190123175723_add_topology_portfolioitem_fields.rb
+++ b/db/migrate/20190123175723_add_topology_portfolioitem_fields.rb
@@ -1,0 +1,9 @@
+class AddTopologyPortfolioitemFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :portfolio_items, :display_name, :string
+    add_column :portfolio_items, :long_description, :string
+    add_column :portfolio_items, :provider_display_name, :string
+    add_column :portfolio_items, :documentation_url, :string
+    add_column :portfolio_items, :support_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190116194409) do
+ActiveRecord::Schema.define(version: 2019_01_23_183457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,11 @@ ActiveRecord::Schema.define(version: 20190116194409) do
     t.string "service_offering_ref"
     t.bigint "portfolio_id"
     t.string "service_offering_source_ref"
+    t.string "display_name"
+    t.string "long_description"
+    t.string "provider_display_name"
+    t.string "documentation_url"
+    t.string "support_url"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-128

This PR adds five new fields to the `PortfolioItem` class. This will be necessary for the rest of the ticket as I refactor the ServiceOffering to pull in and persist the new fields from topology. 