### PR TITLE
Add basic auth support for Topology API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ export MANAGEIQ_PORT=3000
 
 If the topology inventory requires authentication (ie in dev), basic authentication is supported via these variables. They won't be read in unless :
 ```
-export DEV_TOPOLOGICAL_INVENTORY_USERNAME=myuser
-export DEV_TOPOLOGICAL_INVENTORY_PASSWORD=password
+export DEV_USERNAME=myuser
+export DEV_PASSWORD=password
 ```
 
 This sample was generated with the [swagger-codegen](https://github.com/swagger-api/swagger-codegen) project.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ export MANAGEIQ_HOST=localhost
 export MANAGEIQ_PORT=3000
 ```
 
-If the topology inventory requires authentication, basic authentication is supported via these variables:
+If the topology inventory requires authentication (ie in dev), basic authentication is supported via these variables. They won't be read in unless :
 ```
-export TOPOLOGICAL_INVENTORY_USERNAME=myuser
-export TOPOLOGICAL_INVENTORY_PASSWORD=password
+export DEV_TOPOLOGICAL_INVENTORY_USERNAME=myuser
+export DEV_TOPOLOGICAL_INVENTORY_PASSWORD=password
 ```
 
 This sample was generated with the [swagger-codegen](https://github.com/swagger-api/swagger-codegen) project.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ export MANAGEIQ_HOST=localhost
 export MANAGEIQ_PORT=3000
 ```
 
+If the topology inventory requires authentication, basic authentication is supported via these variables:
+```
+export TOPOLOGICAL_INVENTORY_USERNAME=myuser
+export TOPOLOGICAL_INVENTORY_PASSWORD=password
+```
+
 This sample was generated with the [swagger-codegen](https://github.com/swagger-api/swagger-codegen) project.
 
 ```

--- a/lib/topological_inventory.rb
+++ b/lib/topological_inventory.rb
@@ -18,8 +18,8 @@ class TopologicalInventory
       config.scheme = URI.parse(ENV['TOPOLOGICAL_INVENTORY_URL']).try(:scheme) || 'http'
       # Set up user/pass for basic auth if we're in dev and they exist.
       if Rails.env.development?
-        config.username = ENV['DEV_TOPOLOGICAL_INVENTORY_USERNAME'] || nil
-        config.password = ENV['DEV_TOPOLOGICAL_INVENTORY_PASSWORD'] || nil
+        config.username = ENV['DEV_USERNAME'] || raise("Empty ENV variable: DEV_USERNAME")
+        config.password = ENV['DEV_PASSWORD'] || raise("Empty ENV variable: DEV_PASSWORD")
       end
     end
     TopologicalInventoryApiClient::DefaultApi.new

--- a/lib/topological_inventory.rb
+++ b/lib/topological_inventory.rb
@@ -14,7 +14,12 @@ class TopologicalInventory
 
   private_class_method def self.raw_api
     TopologicalInventoryApiClient.configure do |config|
-      config.host   = ENV['TOPOLOGICAL_INVENTORY_URL'] || 'localhost'
+      config.host = ENV['TOPOLOGICAL_INVENTORY_URL'] || 'localhost'
+
+      # Set up auth if we need it, mainly for debugging on local workstations
+      config.username = ENV['TOPOLOGICAL_INVENTORY_USERNAME'] || nil
+      config.password = ENV['TOPOLOGICAL_INVENTORY_PASSWORD'] || nil
+
       config.scheme = URI.parse(ENV['TOPOLOGICAL_INVENTORY_URL']).try(:scheme) || 'http'
     end
     TopologicalInventoryApiClient::DefaultApi.new

--- a/lib/topological_inventory.rb
+++ b/lib/topological_inventory.rb
@@ -15,9 +15,12 @@ class TopologicalInventory
   private_class_method def self.raw_api
     TopologicalInventoryApiClient.configure do |config|
       config.host = ENV['TOPOLOGICAL_INVENTORY_URL'] || 'localhost'
-      config.username = ENV['TOPOLOGICAL_INVENTORY_USERNAME'] || nil
-      config.password = ENV['TOPOLOGICAL_INVENTORY_PASSWORD'] || nil
       config.scheme = URI.parse(ENV['TOPOLOGICAL_INVENTORY_URL']).try(:scheme) || 'http'
+      # Set up user/pass for basic auth if we're in dev and they exist.
+      if Rails.env.development?
+        config.username = ENV['DEV_TOPOLOGICAL_INVENTORY_USERNAME'] || nil
+        config.password = ENV['DEV_TOPOLOGICAL_INVENTORY_PASSWORD'] || nil
+      end
     end
     TopologicalInventoryApiClient::DefaultApi.new
   end

--- a/lib/topological_inventory.rb
+++ b/lib/topological_inventory.rb
@@ -15,11 +15,8 @@ class TopologicalInventory
   private_class_method def self.raw_api
     TopologicalInventoryApiClient.configure do |config|
       config.host = ENV['TOPOLOGICAL_INVENTORY_URL'] || 'localhost'
-
-      # Set up auth if we need it, mainly for debugging on local workstations
       config.username = ENV['TOPOLOGICAL_INVENTORY_USERNAME'] || nil
       config.password = ENV['TOPOLOGICAL_INVENTORY_PASSWORD'] || nil
-
       config.scheme = URI.parse(ENV['TOPOLOGICAL_INVENTORY_URL']).try(:scheme) || 'http'
     end
     TopologicalInventoryApiClient::DefaultApi.new


### PR DESCRIPTION
During initial development, hitting Topology from the Service Catalog required no authentication. Since battening down the hatches we now need basic authentication to hit the API. This pull requests adds setting basic auth fields on the request configuration, so we can get the information from Topology. They default to nil though just in case auth isn't required.

The README has also been updated to reflect these changes. 
