### PR TITLE
Handle blank params

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -26,13 +26,13 @@ module Api
       end
 
       def fetch_portfolio_with_id
-        render json: Portfolio.find(params.require(:portfolio_id))
+        json_response(Portfolio.find(params.require(:portfolio_id)))
       end
 
       def fetch_portfolio_item_from_portfolio
         item = Portfolio.find(params.require(:portfolio_id))
           .portfolio_items.find(params.require(:portfolio_item_id))
-        render json: item
+        json_response(item)
       end
 
       def fetch_portfolio_items_with_portfolio

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::API
+  include Response
+  include ExceptionHandler
+  include Request
+  before_action :validate_params
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,18 @@
+module ExceptionHandler
+  # provides the more graceful `included` method
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      json_response({ :message => e.message }, :not_found)
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      json_response({ :message => e.message }, :unprocessable_entity)
+    end
+
+    rescue_from ActionController::ParameterMissing do |e|
+      json_response({ :message => e.message }, :unprocessable_entity)
+    end
+  end
+end

--- a/app/controllers/concerns/request.rb
+++ b/app/controllers/concerns/request.rb
@@ -1,0 +1,13 @@
+module Request
+  def validate_params(_params = nil)
+    req_params = _params || request.params
+    req_params.each do |_, v|
+      if v.instance_of?(ActionController::Parameters)
+        clean_params(v)
+      end
+      if v.empty? || v == '' || v == "''"
+        raise ActiveRecord::RecordInvalid
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/request.rb
+++ b/app/controllers/concerns/request.rb
@@ -1,11 +1,11 @@
 module Request
-  def validate_params(_params = nil)
-    req_params = _params || request.params
-    req_params.each do |_, v|
-      if v.instance_of?(ActionController::Parameters)
-        clean_params(v)
+  def validate_params(params = nil)
+    req_params = params || request.params
+    req_params.each_value do |val|
+      if val.kind_of?(ActiveSupport::HashWithIndifferentAccess)
+        validate_params(val)
       end
-      if v.empty? || v == '' || v == "''"
+      if val.empty? || val == '' || val == "''"
         raise ActiveRecord::RecordInvalid
       end
     end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,0 +1,5 @@
+module Response
+  def json_response(object, status = :ok)
+    render json: object, status: status
+  end
+end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,5 +1,5 @@
 module Response
   def json_response(object, status = :ok)
-    render json: object, status: status
+    render :json => object, :status => status
   end
 end

--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -242,6 +242,8 @@ paths:
           $ref: '#/responses/Forbidden'
         '404':
           description: Either the Portfolio ID or the Portfolio Item ID was not found
+        '422':
+          $ref: '#/responses/InvalidEntity'
   /portfolio_items:
     get:
       tags:

--- a/spec/requests/portfolios_spec.rb
+++ b/spec/requests/portfolios_spec.rb
@@ -28,6 +28,30 @@ describe 'Portfolios API' do
       end
     end
 
+    describe "GET #{tag} tagged /portfolios?portfolio_id=''" do
+      before do
+        get "#{api}/portfolios?portfolio_id=''", :headers => send("#{tag}_headers")
+      end
+
+      context 'empty parameter' do
+        it 'returns status code 422' do
+          expect(response).to have_http_status(422)
+        end
+      end
+    end
+
+    describe "GET #{tag} tagged /portfolios?identity%5Bportfolio_id%5D=" do
+      before do
+        get "#{api}/portfolios?identity%5Bportfolio_id%5D=", :headers => send("#{tag}_headers")
+      end
+
+      context 'empty nested parameter' do
+        it 'returns status code 422' do
+          expect(response).to have_http_status(422)
+        end
+      end
+    end
+
     describe "GET #{tag} tagged /portfolios/:portfolio_id/portfolio_items" do
       before do
         get "#{api}/portfolios/#{portfolio_id}/portfolio_items", :headers => send("#{tag}_headers")


### PR DESCRIPTION
Pre validating params with a check to see if any are empty or blank.
If empty, blank raise ActiveRecord::RecordInvalid
Create an exception handler to rescue_from and modify the error
to a 422 unprocessable_intity

Also add the `Response` and `ExceptionHandler` concerns as currently implemented in the Approval API

Added a new concern: `Response` to handle validating the params.

Jira Ticket: https://projects.engineering.redhat.com/browse/SSP-149