### PR TITLE
Switched access to collection.data instead of array

### DIFF
--- a/app/services/service_catalog/provider_control_parameters.rb
+++ b/app/services/service_catalog/provider_control_parameters.rb
@@ -10,7 +10,7 @@ module ServiceCatalog
       source_ref = PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
       TopologicalInventory.call do |api_instance|
         # TODO: Temporay till we get this call in the topology service
-        projects = api_instance.list_container_projects.select { |p| p.source_id == source_ref }
+        projects = api_instance.list_container_projects.data.select { |p| p.source_id == source_ref }
         update_project_list(projects.collect(&:name))
         self
       end

--- a/app/services/service_catalog/service_plans.rb
+++ b/app/services/service_catalog/service_plans.rb
@@ -9,7 +9,7 @@ module ServiceCatalog
       ref = PortfolioItem.find(@portfolio_item_id).service_offering_ref
       TopologicalInventory.call do |api_instance|
         result = api_instance.list_service_offering_service_plans(ref)
-        @items = filter_result(result)
+        @items = filter_result(result.data)
       end
       self
     rescue StandardError => e

--- a/spec/services/service_catalog/provider_control_parameters_spec.rb
+++ b/spec/services/service_catalog/provider_control_parameters_spec.rb
@@ -25,7 +25,8 @@ describe ServiceCatalog::ProviderControlParameters do
   end
 
   it "#{described_class}#process" do
-    expect(api_instance).to receive(:list_container_projects).and_return([project1, project2])
+    result = double('links' => {}, 'meta' => {}, 'data' => [project1, project2])
+    expect(api_instance).to receive(:list_container_projects).and_return(result)
 
     data = provider_control_parameters.process.data
     expect(data['properties']['namespace']['enum'].first).to eq("project one")

--- a/spec/services/service_catalog/service_plans_spec.rb
+++ b/spec/services/service_catalog/service_plans_spec.rb
@@ -16,7 +16,8 @@ describe ServiceCatalog::ServicePlans do
     Plan = Struct.new(:name, :id, :description, :create_json_schema)
     plan1 = Plan.new("Plan A", "1", "Plan A", {})
     plan2 = Plan.new("Plan B", "2", "Plan B", {})
-    expect(api_instance).to receive(:list_service_offering_service_plans).with(portfolio_item.service_offering_ref).and_return([plan1, plan2])
+    result = double('links' => {}, 'meta' => {}, 'data' => [plan1, plan2])
+    expect(api_instance).to receive(:list_service_offering_service_plans).with(portfolio_item.service_offering_ref).and_return(result)
 
     expect(service_plans.process.items.count).to eq(2)
   end


### PR DESCRIPTION
Since we are using the new Topology Gem the result is coming back
as a hash with links, meta and data. This PR fixes the 2 calls in
service portal that use the collection objects coming back from
the topology service