### PR TITLE
Allow for v0 redirects on api requests

### DIFF
--- a/config/initializers/action_dispatch-routing-option_redirect.rb
+++ b/config/initializers/action_dispatch-routing-option_redirect.rb
@@ -1,0 +1,20 @@
+module OptionRedirectEnhancements
+  def serve(req)
+    uri = URI.parse(path(req.path_parameters, req))
+
+    req.commit_flash
+
+    body = %(<html><body>You are being <a href="#{ERB::Util.unwrapped_html_escape(uri.to_s)}">redirected</a>.</body></html>)
+
+    headers = {
+      "Location" => uri.to_s,
+      "Content-Type" => "text/html",
+      "Content-Length" => body.length.to_s
+    }
+
+    [ status, headers, [body] ]
+  end
+end
+
+require 'action_dispatch/routing/redirection'
+ActionDispatch::Routing::OptionRedirect.prepend(OptionRedirectEnhancements)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     # Convert codegen substitutions into Symbols
     full_path = path.gsub(/{(.*?)}/, ':\1')
     scope :as => :api, :module => "api", :path => prefix do
+      match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v0.0/%{path}", :only_path => true)
       namespace :v0x0, :path => "v0.0" do
         match full_path, :to => "#{opts.fetch(:controller_name)}##{opts[:action_name]}", :via => http_method
       end

--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe ApplicationController, :type => :request do
   let!(:external_tenant)  { (Time.zone.now.to_i * rand(1000)).to_s }
   let(:identity)          { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
 
+  context "with api version v0" do
+    let(:api_version)       { api(0) }
+    let(:api_minor_version) { api }
+
+    it "get api/v0/portfolios with tenant" do
+      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
+
+      get("#{api_version}/portfolios/#{portfolio_id}", :headers => headers)
+      expect(response.status).to eq(301)
+      expect(response.headers["Location"]).to eq "#{api_minor_version}/portfolios/#{portfolio_id}"
+    end
+
+    it "get api/v0/portfolios without tenant" do
+      headers = { "CONTENT_TYPE" => "application/json" }
+
+      get("#{api_version}/portfolios/#{portfolio_id}", :headers => headers)
+      expect(response.status).to eq(301)
+      expect(response.headers["Location"]).to eq "#{api_minor_version}/portfolios/#{portfolio_id}"
+    end
+  end
+
   context "with tenancy enforcement" do
     after  { controller.send(:set_current_tenant, nil) }
 

--- a/spec/support/requests_spec_helper.rb
+++ b/spec/support/requests_spec_helper.rb
@@ -4,8 +4,8 @@ module RequestSpecHelper
     JSON.parse(response.body)
   end
 
-  def api
-    "/api/v0.0"
+  def api(version = 0.0)
+    "/api/v#{version}"
   end
 
   def disable_tenancy


### PR DESCRIPTION
Adds route and mixin to facilitate redirects for major version numbers e.g. `/api/v0/portfolios`

Redirect Mixin from: https://github.com/ManageIQ/topological_inventory-api/blob/master/config/initializers/action_dispatch-routing-option_redirect.rb

Redirect matching rule from: https://github.com/ManageIQ/topological_inventory-api/blob/master/config/routes.rb#L11

Both in Topology via @bdunne