### PR TITLE
Add migration for icons

### DIFF
--- a/db/migrate/20190206223630_create_icons.rb
+++ b/db/migrate/20190206223630_create_icons.rb
@@ -1,0 +1,13 @@
+class CreateIcons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :icons do |t|
+      t.string :source_ref
+      t.string :data
+
+      t.timestamps
+    end
+
+    add_column :portfolio_items, :service_offering_icon_id, :bigint
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_31_192312) do
+ActiveRecord::Schema.define(version: 2019_02_06_223630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "icons", force: :cascade do |t|
+    t.string "source_ref"
+    t.string "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "order_items", force: :cascade do |t|
     t.integer "count"
@@ -60,6 +67,7 @@ ActiveRecord::Schema.define(version: 2019_01_31_192312) do
     t.string "provider_display_name"
     t.string "documentation_url"
     t.string "support_url"
+    t.bigint "service_offering_icon_id"
     t.index ["tenant_id"], name: "index_portfolio_items_on_tenant_id"
   end
 

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -22,7 +22,7 @@ describe ServiceOffering::AddToPortfolioItem do
     item = add_to_portfolio_item.process.item
 
     expect(item).to be_a(PortfolioItem)
-    expect(item.attributes.count).to eql(17)
+    expect(item.attributes.count).to eql(18)
 
     # Does it have all the attributes transferred over that we set up above?
     # noinspection RubyResolve
@@ -34,7 +34,8 @@ describe ServiceOffering::AddToPortfolioItem do
       'display_name'                => topology_service_offering.display_name,
       'long_description'            => topology_service_offering.long_description,
       'documentation_url'           => topology_service_offering.documentation_url,
-      'support_url'                 => topology_service_offering.support_url
+      'support_url'                 => topology_service_offering.support_url,
+      'service_offering_icon_id'    => topology_service_offering.service_offering_icon_id
     )
   end
 
@@ -52,9 +53,9 @@ describe ServiceOffering::AddToPortfolioItem do
   it "#{described_class}#determine_valid_fields" do
     add_to_portfolio_item.instance_variable_set("@service_offering", topology_service_offering)
 
-    expect(topology_service_offering.instance_variables.count).to eql 9
+    expect(topology_service_offering.instance_variables.count).to eql 10
     filtered = add_to_portfolio_item.send(:determine_valid_fields)
-    expect(filtered.count).to eql 8
+    expect(filtered.count).to eql 9
   end
 
   it "#{described_class}#create_param_map(params)" do

--- a/spec/support/service_offering_topological_service_offering_helper.rb
+++ b/spec/support/service_offering_topological_service_offering_helper.rb
@@ -9,7 +9,8 @@ module ServiceOfferingHelper
       :display_name      => "test display name",
       :long_description  => "test long description",
       :documentation_url => "http://test.docs.io",
-      :support_url       => "800-555-TEST"
+      :support_url       => "800-555-TEST",
+      :service_offering_icon_id => 19
     )
   end
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-129

This PR adds the database migration required for icon support in the API (jira ticket above). 

It involves creating an icons table, and then adding a foreign key to the portfolio_item table. The ServiceOffering::AddToPortfolioItem service will automatically populate this field on data retrieval. 