### PR TITLE
Updated docs for DELETE /portfolio with proper response

### DIFF
--- a/public/service_portal/v0.1.0/openapi.json
+++ b/public/service_portal/v0.1.0/openapi.json
@@ -189,24 +189,11 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "Edited portfolio object",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Portfolio"
-                                }
-                            }
-                        }
+                    "204": {
+                        "description": "Portfolio Deleted"
                     },
-                    "401": {
-                        "$ref": "#/components/responses/Unauthorized"
-                    },
-                    "403": {
-                        "$ref": "#/components/responses/Forbidden"
-                    },
-                    "422": {
-                        "$ref": "#/components/responses/InvalidEntity"
+                    "404": {
+                        "description": "Portfolio Not Found"
                     }
                 }
             }


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-166

This PR fixes the openapi documentation for the DELETE `/portfolios` endpoint. Before it specified a 200 with the portfolio object being returned, now it shows that it returns nothing.