### PR TITLE
Fix POST /portfolio_items error handling on failed lookup from Topology

### DIFF
--- a/app/controllers/api/v0/admins_controller.rb
+++ b/app/controllers/api/v0/admins_controller.rb
@@ -29,6 +29,8 @@ module Api
       def add_portfolio_item
         so = ServiceOffering::AddToPortfolioItem.new(portfolio_item_params)
         render :json => so.process.item
+      rescue ServiceCatalog::TopologyError => e
+        render :json => { :errors => e.message }, :status => :not_found
       end
 
       def add_to_order

--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -20,6 +20,9 @@ module ServiceOffering
 
       @item = PortfolioItem.create!(populate_missing_fields)
       self
+    rescue StandardError => e
+      Rails.logger.error("Service Offering Ref: #{@params[:service_offering_ref]} #{e.message}")
+      raise
     end
 
     private

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -64,6 +64,32 @@ describe "PortfolioItemRequests", :type => :request do
     end
   end
 
+  context "when adding portfolio items" do
+    let(:add_to_portfolio_svc) { double(ServiceOffering::AddToPortfolioItem) }
+    let(:params) { { :service_offering_ref => service_offering_ref } }
+
+    before do
+      allow(ServiceOffering::AddToPortfolioItem).to receive(:new).and_return(add_to_portfolio_svc)
+    end
+
+    it "returns not found when topology doesn't have the service_offering_ref" do
+      allow(add_to_portfolio_svc).to receive(:process).and_raise(topo_ex)
+
+      post "#{api}/portfolio_items", :params => params
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns the new portfolio item when topology has the service_offering_ref" do
+      allow(add_to_portfolio_svc).to receive(:process).and_return(add_to_portfolio_svc)
+      allow(add_to_portfolio_svc).to receive(:item).and_return(portfolio_item)
+
+      post "#{api}/portfolio_items", :params => params
+      expect(response).to have_http_status(:ok)
+      expect(json["id"]).to eq portfolio_item.id
+      expect(json["service_offering_ref"]).to eq service_offering_ref
+    end
+  end
+
   context "service plans" do
     let(:svc_object)           { instance_double("ServiceCatalog::ServicePlans") }
     let(:plans)                { [{}, {}] }


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-123

This PR fixes the response code when adding a `portfolio_item` and the topology service returns a "Not Found" error message, it used to be 500, but we now catch the exception and make sure it's a 404. 