### PR TITLE
Modify what column source_id is mapped to

### DIFF
--- a/app/services/service_offering/add_to_portfolio_item.rb
+++ b/app/services/service_offering/add_to_portfolio_item.rb
@@ -1,6 +1,6 @@
 module ServiceOffering
   class AddToPortfolioItem
-    IGNORE_FIELDS = %w(id created_at updated_at portfolio_id).freeze
+    IGNORE_FIELDS = %w(id created_at updated_at portfolio_id tenant_id).freeze
 
     attr_reader :params
     attr_reader :item
@@ -16,9 +16,7 @@ module ServiceOffering
       end
 
       # Get the fields that we're going to pull over
-      create_param_map(determine_valid_fields)
-
-      @item = PortfolioItem.create!(populate_missing_fields)
+      @item = PortfolioItem.create!(generate_attributes)
       self
     rescue StandardError => e
       Rails.logger.error("Service Offering Ref: #{@params[:service_offering_ref]} #{e.message}")
@@ -27,25 +25,22 @@ module ServiceOffering
 
     private
 
-    def determine_valid_fields
-      # These are the fields that topology gave us, so we want to pull them into our model.
-      # Along the way we map them to their string counterparts, then reject the columsn we don't need
-      @service_offering.instance_variables
-                       .map { |var| var.to_s.delete("@") }
-                       .reject { |field| IGNORE_FIELDS.include?(field) }
+    def creation_fields
+      service_offering_columns = @service_offering.instance_variables.map { |x| x.to_s[1..-1] }
+      portfolio_item_columns = PortfolioItem.column_names - IGNORE_FIELDS
+      service_offering_columns & portfolio_item_columns
     end
 
-    # Move fields from the ServiceOffering Ojbect to our params hash, from which we build our PortfolioItem
-    def create_param_map(fields)
-      # logical AND the column names with the fields we know we have, so we only pull in what is available
-      (PortfolioItem.column_names & fields).each do |column|
-        @params[column] = @service_offering.instance_variable_get("@" + column)
+    def generate_attributes
+      creation_fields.each do |column|
+        @params[column] = @service_offering.send(column) if @service_offering.send(column).present?
       end
+      populate_missing_fields
     end
 
     # If certain fields are empty populate them from the other fields that we do have.
     def populate_missing_fields
-      @params[:service_offering_source_ref] = @service_offering.instance_variable_get("@source_ref")
+      @params[:service_offering_source_ref] = @service_offering.source_id
       # Fill up empty fields if they're empty with fields we already have, this is really easy with the ||= and subsequent || operators
       @params[:long_description] ||= @params[:description] || @params[:display_name]
       @params[:display_name] ||= @params[:name]

--- a/spec/services/service_offering/add_to_portfolio_item_spec.rb
+++ b/spec/services/service_offering/add_to_portfolio_item_spec.rb
@@ -1,4 +1,5 @@
 describe ServiceOffering::AddToPortfolioItem do
+  include ServiceOfferingHelper
   let(:api_instance) { double }
   let(:service_offering_ref) { "1" }
 
@@ -6,7 +7,7 @@ describe ServiceOffering::AddToPortfolioItem do
 
   let(:params) { HashWithIndifferentAccess.new(:name => "test name", :description => "test description") }
 
-  let(:topology_service_offering) { ServiceOfferingHelper.fully_populated_service_offering }
+  let(:topology_service_offering) { fully_populated_service_offering }
   let(:topological_inventory) do
     class_double("TopologicalInventory")
       .as_stubbed_const(:transfer_nested_constants => true)
@@ -30,7 +31,7 @@ describe ServiceOffering::AddToPortfolioItem do
       'name'                        => topology_service_offering.name,
       'description'                 => topology_service_offering.description,
       'service_offering_ref'        => service_offering_ref,
-      'service_offering_source_ref' => topology_service_offering.source_ref,
+      'service_offering_source_ref' => topology_service_offering.source_id,
       'display_name'                => topology_service_offering.display_name,
       'long_description'            => topology_service_offering.long_description,
       'documentation_url'           => topology_service_offering.documentation_url,
@@ -38,31 +39,34 @@ describe ServiceOffering::AddToPortfolioItem do
     )
   end
 
-  it "#{described_class}#populate_missing_fields(params)" do
-    # Send in params which only has 2 fields
-    add_to_portfolio_item.instance_variable_set("@params", params)
-    my_params = add_to_portfolio_item.send(:populate_missing_fields)
+  context "private methods" do
+    let(:service_offering) { build_service_offering(:name => "NameyMcNameFace") }
 
-    # It should have added the extra field (source ref) as well as inferring the values of long_description and display name, giving us 5 total fields.
-    expect(my_params.keys.size).to eql 5
-    expect(my_params[:long_description]).to eq(params[:description])
-    expect(my_params[:display_name]).to eq(params[:name])
-  end
+    before do
+      add_to_portfolio_item.instance_variable_set("@service_offering", service_offering)
+      add_to_portfolio_item.instance_variable_set("@params", params)
+    end
 
-  it "#{described_class}#determine_valid_fields" do
-    add_to_portfolio_item.instance_variable_set("@service_offering", topology_service_offering)
+    it "#{described_class}#creation_fields" do
+      creation_fields = add_to_portfolio_item.send(:creation_fields)
+      expect(creation_fields).to eq ["name"]
+    end
 
-    expect(topology_service_offering.instance_variables.count).to eql 9
-    filtered = add_to_portfolio_item.send(:determine_valid_fields)
-    expect(filtered.count).to eql 8
-  end
+    it "#{described_class}#generate_attributes" do
 
-  it "#{described_class}#create_param_map(params)" do
-    service_offering = ServiceOfferingHelper.build_service_offering(:name => "NameyMcNameFace")
-    add_to_portfolio_item.instance_variable_set("@service_offering", service_offering)
+      my_params = add_to_portfolio_item.send(:generate_attributes)
+      %w(name display_name).each do |name|
+        expect(my_params[name]).to eq "NameyMcNameFace"
+      end
+    end
 
-    param_map = add_to_portfolio_item.send(:create_param_map, add_to_portfolio_item.send(:determine_valid_fields))
-    # Only expected one is name since that's what we added.
-    expect(param_map.count).to eql 1
+    it "#{described_class}#populate_missing_fields(params)" do
+      my_params = add_to_portfolio_item.send(:populate_missing_fields)
+
+      # It should have added the extra field (source ref) as well as inferring the values of long_description and display name, giving us 5 total fields.
+      expect(my_params.keys.size).to eql 5
+      expect(my_params[:long_description]).to eq(params[:description])
+      expect(my_params[:display_name]).to eq(params[:name])
+    end
   end
 end

--- a/spec/support/service_offering_topological_service_offering_helper.rb
+++ b/spec/support/service_offering_topological_service_offering_helper.rb
@@ -1,11 +1,11 @@
 module ServiceOfferingHelper
-  def self.fully_populated_service_offering
+  def fully_populated_service_offering
     TopologicalInventoryApiClient::ServiceOffering.new(
       :id                => 1,
       :name              => "test name",
       :description       => "test description",
       :source_ref        => '123',
-      :source_id         => 45,
+      :source_id         => '45',
       :display_name      => "test display name",
       :long_description  => "test long description",
       :documentation_url => "http://test.docs.io",
@@ -13,7 +13,7 @@ module ServiceOfferingHelper
     )
   end
 
-  def self.build_service_offering(params)
+  def build_service_offering(params)
     TopologicalInventoryApiClient::ServiceOffering.new(params)
   end
 end


### PR DESCRIPTION
The `service_offering_source_ref` needs to be mapped to the `source_id` off the Topology request.

This PR makes that change, and modifies the mapping to make use of method names as opposed to `instance_variables`.