### PR TITLE
Change to list container_projects directly on a source

### DIFF
--- a/app/services/service_catalog/provider_control_parameters.rb
+++ b/app/services/service_catalog/provider_control_parameters.rb
@@ -10,7 +10,7 @@ module ServiceCatalog
       source_ref = PortfolioItem.find(@portfolio_item_id).service_offering_source_ref
       TopologicalInventory.call do |api_instance|
         # TODO: Temporay till we get this call in the topology service
-        projects = api_instance.list_container_projects.data.select { |p| p.source_id == source_ref }
+        projects = api_instance.list_source_container_projects(source_ref).data
         update_project_list(projects.collect(&:name))
         self
       end

--- a/spec/services/service_catalog/provider_control_parameters_spec.rb
+++ b/spec/services/service_catalog/provider_control_parameters_spec.rb
@@ -24,7 +24,7 @@ describe ServiceCatalog::ProviderControlParameters do
 
   it "#{described_class}#process" do
     result = double('links' => {}, 'meta' => {}, 'data' => [project1, project2])
-    expect(api_instance).to receive(:list_container_projects).and_return(result)
+    expect(api_instance).to receive(:list_source_container_projects).and_return(result)
 
     data = provider_control_parameters.process.data
     expect(data['properties']['namespace']['enum'].first).to eq("project one")


### PR DESCRIPTION
Change to list container_projects directly on a source instead of listing all container_projects in the tenant and selecting the ones for the specific source.

We are not paging over the returned data and listing all projects in the tenant did not return any items for the destination source.  The new call only returns projects for the source which limits the amount of data returned and removes the need to `select` them.

We still need to implement paging, but this is definitely the preferred approach to list projects per source.