### PR TITLE
Add PATCH support for Portfolio Items

### DIFF
--- a/app/controllers/api/v0x1/portfolio_items_controller.rb
+++ b/app/controllers/api/v0x1/portfolio_items_controller.rb
@@ -18,6 +18,13 @@ module Api
         render :json => { :errors => e.message }, :status => :not_found
       end
 
+      def update
+        portfolio_item = PortfolioItem.find(params.require(:id))
+        portfolio_item.update!(portfolio_item_patch_params)
+
+        render :json => portfolio_item
+      end
+
       def show
         render :json => PortfolioItem.find(params.require(:id))
       end
@@ -31,6 +38,10 @@ module Api
 
       def portfolio_item_params
         params.permit(:service_offering_ref)
+      end
+
+      def portfolio_item_patch_params
+        params.permit(:favorite, :name, :description, :orphan, :state, :display_name, :long_description, :distributor, :documentation_url, :support_url)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
       resources :portfolios,            :only => [:create, :destroy, :index, :show, :update] do
         resources :portfolio_items,       :only => [:index]
       end
-      resources :portfolio_items,       :only => [:create, :destroy, :index, :show] do
+      resources :portfolio_items,       :only => [:create, :destroy, :index, :show, :update] do
         resources :provider_control_parameters, :only => [:index]
         resources :service_plans,               :only => [:index]
       end

--- a/public/service_portal/v0.1.0/openapi.json
+++ b/public/service_portal/v0.1.0/openapi.json
@@ -413,6 +413,37 @@
             "description": "Portfolio Item not Found"
           }
         }
+      },
+      "patch": {
+        "summary": "Edit an existing Portfolio Item",
+        "description": "Returns the edited Portfolio Item Object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "operationId": "updatePortfolioItem",
+        "responses": {
+          "200": {
+            "description": "Return the updated Portfolio Item object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "description": "The Portfolio Item ID was not found"
+          }
+        }
       }
     },
     "/portfolio_items/{portfolio_item_id}/service_plans": {

--- a/spec/requests/portfolio_items_spec.rb
+++ b/spec/requests/portfolio_items_spec.rb
@@ -242,4 +242,42 @@ describe "PortfolioItemRequests", :type => :request do
       expect(response).to have_http_status(:internal_server_error)
     end
   end
+
+  describe "patching portfolio items" do
+    let(:valid_attributes) { { :name => 'PatchPortfolio', :description => 'PatchDescription' } }
+    let(:invalid_attributes) { { :name => 'PatchPortfolio', :service_offering_ref => "27" } }
+
+    context "when passing in valid attributes" do
+      before do
+        patch "#{api('0.1')}/portfolio_items/#{portfolio_item.id}", :params => valid_attributes
+      end
+
+      it 'returns a 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'patches the record' do
+        expect(json["name"]).to eq valid_attributes[:name]
+        expect(json["description"]).to eq valid_attributes[:description]
+      end
+    end
+
+    context "when passing in read-only attributes" do
+      before do
+        patch "#{api('0.1')}/portfolio_items/#{portfolio_item.id}", :params => invalid_attributes
+      end
+
+      it 'returns a 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the field that is allowed' do
+        expect(json["name"]).to eq invalid_attributes[:name]
+      end
+
+      it "does not update the read-only field" do
+        expect(json["service_offering_ref"]).to_not eq invalid_attributes[:service_offering_ref]
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-195

This PR adds support for editing Portfolio Items using a new HTTP PATCH
endpoint on `/portfolio_items/{id}`.

Followed the same standards as the rest of our endpoints - e.g. don't
throw a 400/500 on bad input just don't update the fields. 

https://github.com/lindgrenj6/service_portal-api/blob/3b8c3a1ec4620d0ee005e518ee8628ce09d6356a/app/controllers/api/v0x1/portfolio_items_controller.rb#L23

Is where I would like some input - I took the ones that I **think**
should be editable instead of read-only from these column names:

```
[1] pry(main)> PortfolioItem.column_names
=> ["id",
 "favorite",
 "name",
 "description",
 "orphan",
 "state",
 "created_at",
 "updated_at",
 "tenant_id",
 "service_offering_ref",
 "portfolio_id",
 "service_offering_source_ref",
 "display_name",
 "long_description",
 "distributor",
 "documentation_url",
 "support_url",
 "discarded_at"]

```