### PR TITLE
Forward Headers to topology service

### DIFF
--- a/lib/topological_inventory.rb
+++ b/lib/topological_inventory.rb
@@ -22,8 +22,7 @@ class TopologicalInventory
   end
 
   private_class_method def self.pass_thru_headers
-    # TODO: Get headers from request
-    headers = {}
+    headers = ManageIQ::API::Common::Headers.current_forwardable
     api.api_client.default_headers = api.api_client.default_headers.merge(headers)
   end
 end

--- a/lib/topological_inventory.rb
+++ b/lib/topological_inventory.rb
@@ -22,7 +22,7 @@ class TopologicalInventory
   end
 
   private_class_method def self.pass_thru_headers
-    headers = ManageIQ::API::Common::Headers.current_forwardable
+    headers = ManageIQ::API::Common::Request.current_forwardable
     api.api_client.default_headers = api.api_client.default_headers.merge(headers)
   end
 end

--- a/spec/lib/topological_inventory_spec.rb
+++ b/spec/lib/topological_inventory_spec.rb
@@ -3,6 +3,7 @@ describe TopologicalInventory do
 
   it "raises TopologyError" do
     with_modified_env :TOPOLOGICAL_INVENTORY_URL => 'http://www.example.com' do
+      allow(ManageIQ::API::Common::Headers).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call do |_api|
           raise topo_ex

--- a/spec/lib/topological_inventory_spec.rb
+++ b/spec/lib/topological_inventory_spec.rb
@@ -3,7 +3,7 @@ describe TopologicalInventory do
 
   it "raises TopologyError" do
     with_modified_env :TOPOLOGICAL_INVENTORY_URL => 'http://www.example.com' do
-      allow(ManageIQ::API::Common::Headers).to receive(:current_forwardable).and_return(:x => 1)
+      allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call do |_api|
           raise topo_ex


### PR DESCRIPTION
This was pending work the manageiq-common-api gem which added the ability to fetch the forward able headers.
https://github.com/ManageIQ/manageiq-api-common/pull/34