### PR TITLE
Replace Headers with Request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,27 +3,32 @@ class ApplicationController < ActionController::API
   private
 
   set_current_tenant_through_filter
+  before_action :set_current_headers
   before_action :set_the_current_tenant
+  after_action :remove_current_headers_and_tenant
+
+  def set_current_headers
+    ManageIQ::API::Common::Request.current = request
+  end
+
+  def remove_current_headers_and_tenant
+    ManageIQ::API::Common::Request.current = nil
+    ActsAsTenant.current_tenant = nil
+  end
 
   def set_the_current_tenant
     return unless Tenant.tenancy_enabled?
-
-    account_number = identity_account_number
+    begin
+      account_number = ManageIQ::API::Common::Request.current.user.tenant rescue nil
+    rescue ManageIQ::API::Common::HeaderIdentityError
+      account_number = nil
+    end
     tenant = Tenant.find_or_create_by(:external_tenant => account_number) if account_number.present?
     if tenant
       set_current_tenant(tenant)
     else
       render :json => { :errors => "Unauthorized" }, :status => :unauthorized
     end
-  end
-
-  def identity_account_number
-    ident_key = "x-rh-identity"
-    ManageIQ::API::Common::Headers.current = request.headers
-    return unless ManageIQ::API::Common::Headers.current.key?(ident_key)
-
-    ident = JSON.parse(Base64.decode64(request.headers[ident_key]))
-    ident.fetch_path("identity", "account_number")
   end
 
   def topology_service_error(err)

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,0 +1,5 @@
+module Response
+  def json_response(object, status = :ok)
+    render :json => object, :status => status
+  end
+end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,4 +1,5 @@
 module ServiceCatalog
   class TopologyError < StandardError; end
   class RBACError < StandardError; end
+  class NoTenantError < StandardError; end
 end

--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe ApplicationController, :type => :request do
-  include UserHeaderSpecHelper
 
   let(:tenant)            { Tenant.create(:external_tenant => external_tenant) }
   let(:portfolio)         { Portfolio.create!(:name => 'tenant_portfolio', :description => 'tenant desc', :tenant_id => tenant.id) }
   let(:portfolio_id)      { portfolio.id }
-  let!(:external_tenant)  { (Time.zone.now.to_i * rand(1000)).to_s }
+  let!(:external_tenant)  { "0369233" }
   let(:other_user)        { default_user_hash }
 
   let(:identity) do
@@ -34,7 +33,6 @@ RSpec.describe ApplicationController, :type => :request do
   end
 
   context "with tenancy enforcement" do
-    after  { controller.send(:set_current_tenant, nil) }
 
     it "get /portfolios with tenant" do
       headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
@@ -71,7 +69,6 @@ RSpec.describe ApplicationController, :type => :request do
 
   context "without tenancy enforcement" do
     before { disable_tenancy }
-    after { controller.send(:set_current_tenant, nil) }
 
     it "get /portfolios" do
       headers = { "CONTENT_TYPE" => "application/json" }

--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -1,10 +1,16 @@
 RSpec.describe ApplicationController, :type => :request do
+  include UserHeaderSpecHelper
 
   let(:tenant)            { Tenant.create(:external_tenant => external_tenant) }
   let(:portfolio)         { Portfolio.create!(:name => 'tenant_portfolio', :description => 'tenant desc', :tenant_id => tenant.id) }
   let(:portfolio_id)      { portfolio.id }
   let!(:external_tenant)  { (Time.zone.now.to_i * rand(1000)).to_s }
-  let(:identity)          { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
+  let(:other_user)        { default_user_hash }
+
+  let(:identity) do
+    other_user['identity']['account_number'] = external_tenant
+    encoded_user_hash(other_user)
+  end
 
   context "with api version v0" do
     let(:api_version)       { api(0) }

--- a/spec/factories/tenants.rb
+++ b/spec/factories/tenants.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:external_tenant) { |n| n + rand(1000) }
 
     trait :with_external_tenant do
-      external_tenant { '111' }
+      external_tenant { "0369233" }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.include UserHeaderSpecHelper
   config.include FactoryBot::Syntax::Methods
 
   config.include RequestSpecHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[ManageIQ::API::Common::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/service_spec_helper.rb
+++ b/spec/support/service_spec_helper.rb
@@ -4,12 +4,14 @@ module ServiceSpecHelper
   end
 
   def admin_headers
-    value = Base64.encode64({'identity' => {'is_org_admin' => true }}.to_json)
-    { 'x-rh-auth-identity' => value }
+    default_headers
   end
 
   def user_headers
-    value = Base64.encode64({'identity' => {'is_org_admin' => false }}.to_json)
-    { 'x-rh-auth-identity' => value }
+    default_headers
+  end
+
+  def default_headers
+    { 'x-rh-identity' => encoded_user_hash }
   end
 end


### PR DESCRIPTION
Add `around_action` for setting the Request and Tenant using `ManageIQ::API::Common::Request.with_request(request)`
-- note
`tenant = current_user.tenant rescue nil` will be fixed in this Issue: https://github.com/ManageIQ/manageiq-api-common/issues/41