### PR TITLE
Changed to use limit and offset in RBAC service

### DIFF
--- a/lib/rbac/service.rb
+++ b/lib/rbac/service.rb
@@ -11,7 +11,7 @@ module RBAC
 
     def self.paginate(obj, method, pagination_options, *method_args)
       Enumerator.new do |enum|
-        opts = { 'page_size' => 10, 'page' => 1 }.merge(pagination_options)
+        opts = { 'limit' => 10, 'offset' => 0 }.merge(pagination_options)
         count = nil
         fetched = 0
         begin
@@ -19,7 +19,7 @@ module RBAC
             args = [method_args, opts].flatten.compact
             result = obj.send(method, *args)
             count ||= result.meta.count
-            opts['page'] = opts['page'] + 1
+            opts['offset'] = opts['offset'] + result.data.count
             result.data.each do |element|
               enum.yield element
             end
@@ -41,7 +41,7 @@ module RBAC
     end
 
     private_class_method def self.init(klass)
-      headers = ManageIQ::API::Common::Headers.current_forwardable
+      headers = ManageIQ::API::Common::Request.current_forwardable
       klass.new.tap do |api|
         api.api_client.default_headers = api.api_client.default_headers.merge(headers)
       end

--- a/spec/lib/rbac/service_spec.rb
+++ b/spec/lib/rbac/service_spec.rb
@@ -3,8 +3,8 @@ describe RBAC::Service do
   let(:page_size) { 3 }
   let(:page1_data) { [1, 2, 3] }
   let(:page2_data) { [4, 5, 6] }
-  let(:page1_args) { { 'page' => 1, 'page_size' => page_size } }
-  let(:page2_args) { { 'page' => 2, 'page_size' => page_size } }
+  let(:page1_args) { { 'limit' => page_size, 'offset' => 0 } }
+  let(:page2_args) { { 'limit' => page_size, 'offset' => 3 } }
   let(:meta) { double('count' => 6) }
   let(:result1) { double(:meta => meta, :data => page1_data) }
   let(:result2) { double(:meta => meta, :data => page2_data) }
@@ -12,7 +12,7 @@ describe RBAC::Service do
 
   it "raises RBACError" do
     with_modified_env :RBAC_URL => 'http://www.example.com' do
-      allow(ManageIQ::API::Common::Headers).to receive(:current_forwardable).and_return(:x => 1)
+      allow(ManageIQ::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
       expect do
         described_class.call(RBACApiClient::StatusApi) do |_klass|
           raise rbac_ex
@@ -25,19 +25,19 @@ describe RBAC::Service do
     it "paginates" do
       allow(obj).to receive(:dummy).with(page1_args).and_return(result1)
       allow(obj).to receive(:dummy).with(page2_args).and_return(result2)
-      expect(described_class.paginate(obj, :dummy, 'page_size' => page_size).to_a.size).to eq(6)
+      expect(described_class.paginate(obj, :dummy, 'limit' => page_size).to_a.size).to eq(6)
     end
 
     it "paginates with extra_args" do
       allow(obj).to receive(:dummy).with("extra_arg", page1_args).and_return(result1)
       allow(obj).to receive(:dummy).with("extra_arg", page2_args).and_return(result2)
-      expect(described_class.paginate(obj, :dummy, { 'page_size' => 3 }, "extra_arg").to_a.size).to eq(6)
+      expect(described_class.paginate(obj, :dummy, { 'limit' => 3 }, "extra_arg").to_a.size).to eq(6)
     end
 
     it "handles exception" do
       allow(obj).to receive(:dummy).with(page1_args).and_raise(StandardError.new("kaboom"))
       expect do
-        described_class.paginate(obj, :dummy, 'page_size' => 3).to_a
+        described_class.paginate(obj, :dummy, 'limit' => 3).to_a
       end.to raise_exception(StandardError)
     end
   end


### PR DESCRIPTION
The RBAC service has changed to use limit and offset to
be consistent with the IPP recommendation

https://github.com/RedHatInsights/insights-rbac/pull/29